### PR TITLE
Corrected test descriptions for email-verification parsers

### DIFF
--- a/test/connectors/httpParsers/CreateEmailVerificationRequestHttpParserSpec.scala
+++ b/test/connectors/httpParsers/CreateEmailVerificationRequestHttpParserSpec.scala
@@ -25,36 +25,31 @@ import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.play.test.UnitSpec
 
 class CreateEmailVerificationRequestHttpParserSpec extends UnitSpec with EitherValues {
-  "GetEmailVerifiedHttpReads#read" when {
-    "the response status is OK" should {
-      "return a RegistrationSuccess with the returned SAFE ID" in {
-        val httpResponse: HttpResponse = HttpResponse(
-          responseStatus = CREATED
-        )
 
+  "CreateEmailVerificationRequestHttpReads" when {
+
+    "the response status is CREATED" should {
+
+      "return an EmailVerificationRequestSent object" in {
+        val httpResponse: HttpResponse = HttpResponse(responseStatus = CREATED)
         read("", "", httpResponse).right.value shouldBe EmailVerificationRequestSent
       }
     }
 
-    "the response status is NOT_FOUND" should {
-      "return an InvalidJsonResponse" in {
-        val httpResponse: HttpResponse = HttpResponse(
-          responseStatus = CONFLICT
-        )
+    "the response status is CONFLICT" should {
 
+      "return an EmailAlreadyVerified object" in {
+        val httpResponse: HttpResponse = HttpResponse(responseStatus = CONFLICT)
         read("", "", httpResponse).right.value shouldBe EmailAlreadyVerified
       }
     }
 
-    "the response status is INTERNAL_SERVER_ERROR" should {
-      "return an InvalidJsonResponse" in {
-        val httpResponse: HttpResponse = HttpResponse(
-            responseStatus = INTERNAL_SERVER_ERROR
-        )
+    "the response returns an unexpected status" should {
 
+      "return an error model with the status and response body" in {
+        val httpResponse: HttpResponse = HttpResponse(responseStatus = INTERNAL_SERVER_ERROR)
         read("", "", httpResponse).left.value shouldBe EmailVerificationRequestFailure(INTERNAL_SERVER_ERROR, httpResponse.body)
       }
     }
-
   }
 }

--- a/test/connectors/httpParsers/GetEmailVerificationStateHttpParserSpec.scala
+++ b/test/connectors/httpParsers/GetEmailVerificationStateHttpParserSpec.scala
@@ -25,37 +25,32 @@ import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.play.test.UnitSpec
 
 class GetEmailVerificationStateHttpParserSpec extends UnitSpec with EitherValues {
-  "GetEmailVerifiedHttpReads#read" when {
-    "the response status is OK" should {
-      "return a RegistrationSuccess with the returned SAFE ID" in {
-        val httpResponse: HttpResponse = HttpResponse(
-          responseStatus = OK
-        )
 
+  "GetEmailVerificationStateHttpReads" when {
+
+    "the response status is OK" should {
+
+      "return an EmailVerified object" in {
+        val httpResponse: HttpResponse = HttpResponse(responseStatus = OK)
         read("", "", httpResponse).right.value shouldBe EmailVerified
       }
     }
 
     "the response status is NOT_FOUND" should {
-      "return an InvalidJsonResponse" in {
-        val httpResponse: HttpResponse = HttpResponse(
-          responseStatus = NOT_FOUND
-        )
 
+      "return an EmailNotVerified object" in {
+        val httpResponse: HttpResponse = HttpResponse(responseStatus = NOT_FOUND)
         read("", "", httpResponse).right.value shouldBe EmailNotVerified
       }
     }
 
-    "the response status is INTERNAL_SERVER_ERROR" should {
-      "return an InvalidJsonResponse" in {
-        val httpResponse : HttpResponse = HttpResponse(
-          responseStatus = INTERNAL_SERVER_ERROR
-        )
+    "the response returns an unexpected status" should {
 
+      "return an error model with the status and response body" in {
+        val httpResponse : HttpResponse = HttpResponse(responseStatus = INTERNAL_SERVER_ERROR)
         read("", "", httpResponse).left.value shouldBe GetEmailVerificationStateErrorResponse(INTERNAL_SERVER_ERROR,
           httpResponse.body)
       }
     }
-
   }
 }

--- a/test/services/EmailVerificationServiceSpec.scala
+++ b/test/services/EmailVerificationServiceSpec.scala
@@ -41,13 +41,13 @@ class EmailVerificationServiceSpec extends UnitSpec with MockEmailVerificationCo
   private lazy val continueUrl = mockConfig.emailVerificationBaseUrl
   val testEmail: String = UUID.randomUUID().toString
 
-  "Create Email verifications request" when {
+  "Creating an email verification request" when {
 
     "the email verification feature switch is on" when {
 
-      "the email verification is sent successfully" should {
+      "the email verification request is sent successfully" should {
 
-        "return a StoreEmailSuccess with an emailVerified of false" in {
+        "return Some(true)" in {
 
           mockCreateEmailVerificationRequest(testEmail, continueUrl)(
             Future.successful(Right(EmailVerificationRequestSent))
@@ -62,7 +62,7 @@ class EmailVerificationServiceSpec extends UnitSpec with MockEmailVerificationCo
 
       "the email address has already been verified" should {
 
-        "return a StoreEmailSuccess with an emailVerified of true" in {
+        "return Some(false)" in {
 
           mockCreateEmailVerificationRequest(testEmail, continueUrl)(Future.successful(Right(EmailAlreadyVerified)))
           val res: Option[Boolean] = {
@@ -75,7 +75,7 @@ class EmailVerificationServiceSpec extends UnitSpec with MockEmailVerificationCo
 
       "the email address verification request failed" should {
 
-        "return an EmailVerificationFailure" in {
+        "return None" in {
 
           mockCreateEmailVerificationRequest(testEmail, continueUrl)(
             Future.successful(Left(EmailVerificationRequestFailure(BAD_REQUEST, "")))
@@ -107,7 +107,7 @@ class EmailVerificationServiceSpec extends UnitSpec with MockEmailVerificationCo
   }
 
 
-  "Check Email verifications status request" when {
+  "Checking email verification status" when {
 
     "the email verification feature switch is on" when {
 


### PR DESCRIPTION
As part of BTAT-4523 which implemented the email verification HTTP parsers for vat-agent-client-lookup-frontend, I noticed that the unit test descriptions for these parsers were inaccurate on this service, so I updated them here too.