### PR TITLE
Added inflight email check and redirection

### DIFF
--- a/app/common/SessionKeys.scala
+++ b/app/common/SessionKeys.scala
@@ -20,5 +20,5 @@ object SessionKeys {
   val clientVrn: String = "CLIENT_VRN"
   val emailKey = "Email"
   val validationEmailKey = "validationEmail"
-  val inflightPPOBKey = "inflightPPOB"
+  val inFlightContactDetailsChangeKey = "inFlightContactDetailsChange"
 }

--- a/app/controllers/CaptureEmailController.scala
+++ b/app/controllers/CaptureEmailController.scala
@@ -20,7 +20,7 @@ import audit.AuditingService
 import audit.models.AttemptedEmailAddressAuditModel
 import common.SessionKeys
 import config.{AppConfig, ErrorHandler}
-import controllers.predicates.{AuthPredicate, InflightPPOBPredicate}
+import controllers.predicates.{AuthPredicate, InFlightPPOBPredicate}
 import forms.EmailForm._
 import javax.inject.{Inject, Singleton}
 import play.api.i18n.MessagesApi
@@ -31,7 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class CaptureEmailController @Inject()(val authenticate: AuthPredicate,
-                                       val inflightCheck: InflightPPOBPredicate,
+                                       val inflightCheck: InFlightPPOBPredicate,
                                        val messagesApi: MessagesApi,
                                        val vatSubscriptionService: VatSubscriptionService,
                                        val errorHandler: ErrorHandler,

--- a/app/controllers/ConfirmEmailController.scala
+++ b/app/controllers/ConfirmEmailController.scala
@@ -20,9 +20,9 @@ import javax.inject.{Inject, Singleton}
 
 import audit.AuditingService
 import audit.models.ChangedEmailAddressAuditModel
-import common.SessionKeys.{emailKey, inflightPPOBKey, validationEmailKey}
+import common.SessionKeys.{emailKey, inFlightContactDetailsChangeKey, validationEmailKey}
 import config.{AppConfig, ErrorHandler}
-import controllers.predicates.{AuthPredicate, InflightPPOBPredicate}
+import controllers.predicates.{AuthPredicate, InFlightPPOBPredicate}
 import models.User
 import models.customerInformation.UpdateEmailSuccess
 import play.api.Logger
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ConfirmEmailController @Inject()(val authenticate: AuthPredicate,
-                                       val inflightCheck: InflightPPOBPredicate,
+                                       val inflightCheck: InFlightPPOBPredicate,
                                        val messagesApi: MessagesApi,
                                        val errorHandler: ErrorHandler,
                                        val auditService: AuditingService,
@@ -71,7 +71,7 @@ class ConfirmEmailController @Inject()(val authenticate: AuthPredicate,
               )
             )
 
-            Redirect(routes.EmailChangeSuccessController.show()).removingFromSession(emailKey, validationEmailKey, inflightPPOBKey)
+            Redirect(routes.EmailChangeSuccessController.show()).removingFromSession(emailKey, validationEmailKey, inFlightContactDetailsChangeKey)
           case Left(_) => errorHandler.showInternalServerError
         }
 

--- a/app/controllers/VerifyEmailController.scala
+++ b/app/controllers/VerifyEmailController.scala
@@ -18,7 +18,7 @@ package controllers
 
 import common.SessionKeys
 import config.{AppConfig, ErrorHandler}
-import controllers.predicates.{AuthPredicate, InflightPPOBPredicate}
+import controllers.predicates.{AuthPredicate, InFlightPPOBPredicate}
 import javax.inject.{Inject, Singleton}
 
 import models.User
@@ -31,7 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class VerifyEmailController @Inject()(val authenticate: AuthPredicate,
-                                      val inflightCheck: InflightPPOBPredicate,
+                                      val inflightCheck: InFlightPPOBPredicate,
                                       val messagesApi: MessagesApi,
                                       val emailVerificationService: EmailVerificationService,
                                       val errorHandler: ErrorHandler,

--- a/app/models/customerInformation/CustomerInformation.scala
+++ b/app/models/customerInformation/CustomerInformation.scala
@@ -22,8 +22,19 @@ import play.api.libs.json.{JsPath, Reads, Writes}
 case class CustomerInformation(ppob: PPOB,
                                pendingChanges: Option[PendingChanges]) {
 
-  val addressAndPendingMatch: Boolean =
+  val approvedAndPendingPPOBAddressMatch: Boolean =
     ppob.address equals pendingChanges.flatMap(_.ppob.map(_.address)).getOrElse("")
+
+  val approvedAndPendingEmailAddressMatch: Boolean = {
+    val approvedEmail: Option[String] = ppob.contactDetails.flatMap(_.emailAddress)
+    val pendingEmail: Option[String] = for {
+      pendingChanges <- pendingChanges
+      ppob <- pendingChanges.ppob
+      contactDetails <- ppob.contactDetails
+      emailAddress <- contactDetails.emailAddress
+    } yield emailAddress
+    approvedEmail equals pendingEmail
+  }
 }
 
 object CustomerInformation {

--- a/it/pages/BasePageISpec.scala
+++ b/it/pages/BasePageISpec.scala
@@ -31,7 +31,7 @@ trait BasePageISpec extends IntegrationBaseSpec {
   def formatEmail: Option[String] => Map[String, String] =
     _.fold(Map.empty[String, String])(x => Map(SessionKeys.emailKey -> x))
   def formatInflightPPOB: Option[String] => Map[String, String] =
-    _.fold(Map.empty[String, String])(x => Map(SessionKeys.inflightPPOBKey -> x))
+    _.fold(Map.empty[String, String])(x => Map(SessionKeys.inFlightContactDetailsChangeKey -> x))
 
   def httpPostAuthenticationTests(path: String, sessionVrn: Option[String] = None)(formData: Map[String, Seq[String]]): Unit =
     authenticationTests(path, post(path, formatSessionVrn(sessionVrn))(formData))

--- a/it/pages/ConfirmEmailPageSpec.scala
+++ b/it/pages/ConfirmEmailPageSpec.scala
@@ -183,7 +183,7 @@ class ConfirmEmailPageSpec extends BasePageISpec {
 
             SessionCookieCrumbler.getSessionMap(result).get(SessionKeys.emailKey) shouldBe None
             SessionCookieCrumbler.getSessionMap(result).get(SessionKeys.validationEmailKey) shouldBe None
-            SessionCookieCrumbler.getSessionMap(result).get(SessionKeys.inflightPPOBKey) shouldBe None
+            SessionCookieCrumbler.getSessionMap(result).get(SessionKeys.inFlightContactDetailsChangeKey) shouldBe None
           }
         }
 

--- a/test/assets/CustomerInfoConstants.scala
+++ b/test/assets/CustomerInfoConstants.scala
@@ -143,6 +143,14 @@ object CustomerInfoConstants {
       None
     )))))
 
+  val customerInfoPendingWebsiteModel = CustomerInformation(
+    fullPPOBModel,
+    Some(PendingChanges(Some(PPOB(
+      fullPPOBAddressModel,
+      Some(fullContactDetailsModel),
+      Some("new email")
+    )))))
+
   val fullCustomerInfoJson: JsObject = Json.obj(
     "ppob" -> fullPPOBJson,
     "pendingChanges" -> Some(PendingChanges(Some(fullPPOBModel)))

--- a/test/controllers/CaptureEmailControllerSpec.scala
+++ b/test/controllers/CaptureEmailControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import common.SessionKeys
 import connectors.httpParsers.GetCustomerInfoHttpParser.GetCustomerInfoResponse
-import controllers.predicates.InflightPPOBPredicate
+import controllers.predicates.InFlightPPOBPredicate
 import models.customerInformation._
 import models.errors.ErrorModel
 import org.jsoup.Jsoup

--- a/test/mocks/MockAuth.scala
+++ b/test/mocks/MockAuth.scala
@@ -69,9 +69,9 @@ trait MockAuth extends TestUtil with BeforeAndAfterEach with MockitoSugar with M
       ec
     )
 
-  val mockInflightPPOBPredicate: InflightPPOBPredicate = {
+  val mockInflightPPOBPredicate: InFlightPPOBPredicate = {
 
-    object MockPredicate extends InflightPPOBPredicate(
+    object MockPredicate extends InFlightPPOBPredicate(
       mockVatSubscriptionService,
       mockErrorHandler,
       messagesApi,

--- a/test/models/customerInformation/CustomerInformationSpec.scala
+++ b/test/models/customerInformation/CustomerInformationSpec.scala
@@ -49,5 +49,121 @@ class CustomerInformationSpec extends UnitSpec {
         result shouldBe minCustomerInfoJson
       }
     }
+
+    "approvedAndPendingEmailAddressMatch" when {
+
+      "pending email and approved email are not present" should {
+
+        val model = CustomerInformation(
+          PPOB(
+            minPPOBAddressModel,
+            Some(ContactDetails(None, None, None, None, None)),
+            None
+          ),
+          Some(PendingChanges(
+            Some(PPOB(
+              minPPOBAddressModel,
+              Some(ContactDetails(None, None, None, None, None)),
+              None
+            ))
+          ))
+        )
+
+        "return true" in {
+          model.approvedAndPendingEmailAddressMatch shouldBe true
+        }
+      }
+
+      "pending email does not match approved email" should {
+
+        val model = CustomerInformation(
+          PPOB(
+            minPPOBAddressModel,
+            Some(ContactDetails(None, None, None, Some("email"), None)),
+            None
+          ),
+          Some(PendingChanges(
+            Some(PPOB(
+              minPPOBAddressModel,
+              Some(ContactDetails(None, None, None, Some("different email"), None)),
+              None
+            ))
+          ))
+        )
+
+        "return false" in {
+          model.approvedAndPendingEmailAddressMatch shouldBe false
+        }
+      }
+
+      "pending email matches approved email" should {
+
+        val model = CustomerInformation(
+          PPOB(
+            minPPOBAddressModel,
+            Some(ContactDetails(None, None, None, Some("email"), None)),
+            None
+          ),
+          Some(PendingChanges(
+            Some(PPOB(
+              minPPOBAddressModel,
+              Some(ContactDetails(None, None, None, Some("email"), None)),
+              None
+            ))
+          ))
+        )
+
+        "return true" in {
+          model.approvedAndPendingEmailAddressMatch shouldBe true
+        }
+      }
+    }
+
+    "approvedAndPendingPPOBAddressMatch" when {
+
+      "pending PPOB does not match approved PPOB" should {
+
+        val model = CustomerInformation(
+          PPOB(
+            PPOBAddress("Add", None, None, None, None, None, ""),
+            None,
+            None
+          ),
+          Some(PendingChanges(
+            Some(PPOB(
+              PPOBAddress("Address", None, None, None, None, None, ""),
+              None,
+              None
+            ))
+          ))
+        )
+
+        "return false" in {
+          model.approvedAndPendingPPOBAddressMatch shouldBe false
+        }
+      }
+
+      "pending PPOB matches approved PPOB" should {
+
+        val model = CustomerInformation(
+          PPOB(
+            minPPOBAddressModel,
+            None,
+            None
+          ),
+          Some(PendingChanges(
+            Some(PPOB(
+              minPPOBAddressModel,
+              None,
+              None
+            ))
+          ))
+        )
+
+        "return true" in {
+          model.approvedAndPendingPPOBAddressMatch shouldBe true
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
To test:
1. Login with 110296508 (pending email change) and try to hit `http://localhost:9148/vat-through-software/account/correspondence/change-email-address` (it redirects)
2. Login with 999969202 (pending ppob change) and hit `http://localhost:9148/vat-through-software/account/correspondence/change-email-address` (existing error content shows)