### PR TITLE
Added logger util to bypass play Logger coverage issues

### DIFF
--- a/app/audit/AuditingService.scala
+++ b/app/audit/AuditingService.scala
@@ -20,13 +20,13 @@ import audit.models.{AuditModel, ExtendedAuditModel}
 import config.AppConfig
 import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
-import play.api.Logger
 import play.api.libs.json._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.AuditExtensions
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 import uk.gov.hmrc.play.audit.http.connector.AuditResult.{Disabled, Failure, Success}
 import uk.gov.hmrc.play.audit.model.{DataEvent, ExtendedDataEvent}
+import utils.LoggerUtil.logDebug
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -41,7 +41,7 @@ class AuditingService @Inject()(appConfig: AppConfig, auditConnector: AuditConne
 
   def audit(auditModel: AuditModel, path: String = "-")(implicit hc: HeaderCarrier, ec: ExecutionContext): Unit = {
     val dataEvent = toDataEvent(appConfig.appName, auditModel, path)
-    Logger.debug(s"Splunk Audit Event:\n\n${Json.toJson(dataEvent)}")
+    logDebug(s"Splunk Audit Event:\n\n${Json.toJson(dataEvent)}")
     handleAuditResult(auditConnector.sendEvent(dataEvent))
   }
 
@@ -56,7 +56,7 @@ class AuditingService @Inject()(appConfig: AppConfig, auditConnector: AuditConne
 
   def extendedAudit(auditModel: ExtendedAuditModel, path: String = "-")(implicit hc: HeaderCarrier, ec: ExecutionContext): Unit = {
     val extendedDataEvent = toExtendedDataEvent(appConfig.appName, auditModel, path)
-    Logger.debug(s"Splunk Audit Event:\n\n${Json.toJson(extendedDataEvent)}")
+    logDebug(s"Splunk Audit Event:\n\n${Json.toJson(extendedDataEvent)}")
     handleAuditResult(auditConnector.sendExtendedEvent(extendedDataEvent))
   }
 
@@ -74,13 +74,11 @@ class AuditingService @Inject()(appConfig: AppConfig, auditConnector: AuditConne
   }
 
   private def handleAuditResult(auditResult: Future[AuditResult])(implicit ec: ExecutionContext): Unit = auditResult.map {
-    //$COVERAGE-OFF$ Disabling scoverage as returns Unit, only used for Debug messages
     case Success =>
-      Logger.debug("Splunk Audit Successful")
+      logDebug("Splunk Audit Successful")
     case Failure(err, _) =>
-      Logger.debug(s"Splunk Audit Error, message: $err")
+      logDebug(s"Splunk Audit Error, message: $err")
     case Disabled =>
-      Logger.debug(s"Auditing Disabled")
-    //$COVERAGE-ON$
+      logDebug(s"Auditing Disabled")
   }
 }

--- a/app/connectors/ContactPreferenceConnector.scala
+++ b/app/connectors/ContactPreferenceConnector.scala
@@ -21,9 +21,9 @@ import connectors.httpParsers.ContactPreferenceHttpParser.ContactPreferenceReads
 import connectors.httpParsers.ResponseHttpParser.HttpGetResult
 import javax.inject.{Inject, Singleton}
 import models.contactPreferences.ContactPreference
-import play.api.Logger
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import utils.LoggerUtil.logDebug
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -33,9 +33,7 @@ class ContactPreferenceConnector @Inject()(val http: HttpClient,
 
   def getContactPreference(vrn: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpGetResult[ContactPreference]] = {
     val url: String = config.contactPreferencesUrl(vrn)
-    //$COVERAGE-OFF$
-    Logger.debug(s"[ContactPreferenceConnector][getContactPreference]: Calling contact preferences with URL - $url")
-    //$COVERAGE-ON$
+    logDebug(s"[ContactPreferenceConnector][getContactPreference]: Calling contact preferences with URL - $url")
     http.GET[HttpGetResult[ContactPreference]](url)(ContactPreferenceReads, hc, ec)
   }
 }

--- a/app/connectors/VatSubscriptionConnector.scala
+++ b/app/connectors/VatSubscriptionConnector.scala
@@ -20,9 +20,9 @@ import config.AppConfig
 import connectors.httpParsers.ResponseHttpParser.{HttpGetResult, HttpPutResult}
 import javax.inject.{Inject, Singleton}
 import models.customerInformation.{CustomerInformation, PPOB, UpdateEmailSuccess}
-import play.api.Logger
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import utils.LoggerUtil.{logDebug, logWarn}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -43,10 +43,10 @@ class VatSubscriptionConnector @Inject()(http: HttpClient,
 
     http.GET[HttpGetResult[CustomerInformation]](getCustomerInfoUrl(vrn)).map {
       case customerInfo@Right(_) =>
-        Logger.debug(s"[VatSubscriptionConnector][getCustomerInfo] successfully received customer info response")
+        logDebug(s"[VatSubscriptionConnector][getCustomerInfo] successfully received customer info response")
         customerInfo
       case httpError@Left(error) =>
-        Logger.warn("[VatSubscriptionConnector][getCustomerInfo] received error - " + error.message)
+        logWarn("[VatSubscriptionConnector][getCustomerInfo] received error - " + error.message)
         httpError
     }
   }
@@ -60,7 +60,7 @@ class VatSubscriptionConnector @Inject()(http: HttpClient,
       case result@Right(_) =>
         result
       case httpError@Left(error) =>
-        Logger.warn("[VatSubscriptionConnector][updateEmail] received error - " + error.message)
+        logWarn("[VatSubscriptionConnector][updateEmail] received error - " + error.message)
         httpError
     }
   }

--- a/app/connectors/httpParsers/ContactPreferenceHttpParser.scala
+++ b/app/connectors/httpParsers/ContactPreferenceHttpParser.scala
@@ -20,9 +20,9 @@ import connectors.httpParsers.ResponseHttpParser.HttpGetResult
 import models.contactPreferences.ContactPreference
 import models.contactPreferences.ContactPreference._
 import models.errors.ErrorModel
-import play.api.Logger
 import play.api.http.Status
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+import utils.LoggerUtil.{logDebug, logWarn}
 
 object ContactPreferenceHttpParser {
 
@@ -32,31 +32,23 @@ object ContactPreferenceHttpParser {
 
       response.status match {
         case Status.OK => {
-          //$COVERAGE-OFF$
-          Logger.debug("[ContactPreferencesHttpParser][read]: Status OK")
-          //$COVERAGE-ON$
+          logDebug("[ContactPreferencesHttpParser][read]: Status OK")
           response.json.validate[ContactPreference].fold(
             invalid => {
-              //$COVERAGE-OFF$
-              Logger.debug(s"[ContactPreferencesHttpParser][read]: Invalid Json - $invalid")
-              Logger.warn(s"[ContactPreferencesHttpParser][read]: Invalid Json received from Contact Preferences")
-              //$COVERAGE-ON$
+              logDebug(s"[ContactPreferencesHttpParser][read]: Invalid Json - $invalid")
+              logWarn(s"[ContactPreferencesHttpParser][read]: Invalid Json received from Contact Preferences")
               Left(ErrorModel(Status.INTERNAL_SERVER_ERROR, "Invalid Json received from Contact Preferences"))
             },
             valid => valid.preference.toUpperCase match {
               case `digital` | `paper` => Right(ContactPreference(valid.preference.toUpperCase()))
               case _ =>
-                //$COVERAGE-OFF$
-                Logger.warn(s"[ContactPreferencesHttpParser][read]: Invalid preference type received from Contact Preferences")
-                //$COVERAGE-ON$
+                logWarn(s"[ContactPreferencesHttpParser][read]: Invalid preference type received from Contact Preferences")
                 Left(ErrorModel(Status.INTERNAL_SERVER_ERROR, "Invalid preference type received from Contact Preferences"))
             }
           )
         }
         case status =>
-          //$COVERAGE-OFF$
-          Logger.warn(s"[ContactPreferencesHttpParser][read]: Unexpected Response, Status: $status, Response: ${response.body}")
-          //$COVERAGE-ON$
+          logWarn(s"[ContactPreferencesHttpParser][read]: Unexpected Response, Status: $status, Response: ${response.body}")
           Left(ErrorModel(status, s"Unexpected Response. Response: ${response.body}"))
       }
     }

--- a/app/connectors/httpParsers/CreateEmailVerificationRequestHttpParser.scala
+++ b/app/connectors/httpParsers/CreateEmailVerificationRequestHttpParser.scala
@@ -16,9 +16,9 @@
 
 package connectors.httpParsers
 
-import play.api.Logger
 import play.api.http.Status.{CONFLICT, CREATED}
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+import utils.LoggerUtil.{logDebug, logWarn}
 
 object CreateEmailVerificationRequestHttpParser {
 
@@ -28,26 +28,16 @@ object CreateEmailVerificationRequestHttpParser {
     override def read(method: String, url: String, response: HttpResponse): CreateEmailVerificationRequestResponse =
       response.status match {
         case CREATED =>
-          // $COVERAGE-OFF$
-          Logger.debug(
-            "[CreateEmailVerificationRequestHttpReads][read] - Email request sent successfully"
-          )
-          // $COVERAGE-ON$
+          logDebug("[CreateEmailVerificationRequestHttpReads][read] - Email request sent successfully")
           Right(EmailVerificationRequestSent)
         case CONFLICT =>
-          // $COVERAGE-OFF$
-          Logger.debug(
-            "[CreateEmailVerificationRequestHttpReads][read] - Email already verified"
-          )
-          // $COVERAGE-ON$
+          logDebug("[CreateEmailVerificationRequestHttpReads][read] - Email already verified")
           Right(EmailAlreadyVerified)
         case status =>
-          // $COVERAGE-OFF$
-          Logger.warn(
+          logWarn(
             "[CreateEmailVerificationRequestHttpParser][CreateEmailVerificationRequestHttpReads][read] - " +
             s"Failed to create email verification. Received status: $status Response body: ${response.body}"
           )
-          // $COVERAGE-ON$
           Left(EmailVerificationRequestFailure(status, response.body))
     }
   }

--- a/app/connectors/httpParsers/GetCustomerInfoHttpParser.scala
+++ b/app/connectors/httpParsers/GetCustomerInfoHttpParser.scala
@@ -18,9 +18,9 @@ package connectors.httpParsers
 
 import models.errors.ErrorModel
 import models.customerInformation.CustomerInformation
-import play.api.Logger
 import play.api.http.Status.{OK, INTERNAL_SERVER_ERROR}
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+import utils.LoggerUtil.{logDebug, logWarn}
 
 object GetCustomerInfoHttpParser {
 
@@ -31,23 +31,17 @@ object GetCustomerInfoHttpParser {
       response.status match {
         case OK => response.json.validate[CustomerInformation].fold(
           invalid => {
-            // $COVERAGE-OFF$
-            Logger.warn(s"[GetCustomerInfoHttpParser][read] - Invalid JSON: $invalid")
-            // $COVERAGE-ON$
+            logWarn(s"[GetCustomerInfoHttpParser][read] - Invalid JSON: $invalid")
             Left(ErrorModel(INTERNAL_SERVER_ERROR, "The endpoint returned invalid JSON."))
           },
           valid => {
-            // $COVERAGE-OFF$
-            Logger.debug(s"Successfully parsed the get customer info JSON: $valid")
-            // $COVERAGE-ON$
+            logDebug(s"Successfully parsed the get customer info JSON: $valid")
             Right(valid)
           }
         )
         case status =>
-          // $COVERAGE-OFF$
-          Logger.warn(s"[GetCustomerInfoHttpParser][read]: Unexpected Response, Status $status returned,with " +
+          logWarn(s"[GetCustomerInfoHttpParser][read]: Unexpected Response, Status $status returned,with " +
             s"response: ${response.body}")
-          // $COVERAGE-ON$
           Left(ErrorModel(status, response.body))
       }
     }

--- a/app/connectors/httpParsers/GetEmailVerificationStateHttpParser.scala
+++ b/app/connectors/httpParsers/GetEmailVerificationStateHttpParser.scala
@@ -16,9 +16,9 @@
 
 package connectors.httpParsers
 
-import play.api.Logger
 import play.api.http.Status._
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+import utils.LoggerUtil.{logDebug, logWarn}
 
 object GetEmailVerificationStateHttpParser {
 
@@ -29,19 +29,15 @@ object GetEmailVerificationStateHttpParser {
       response.status match {
         case OK => Right(EmailVerified)
         case NOT_FOUND =>
-          // $COVERAGE-OFF$
-          Logger.debug(
+          logDebug(
             "[GetEmailVerificationStateHttpParser][GetEmailVerificationStateHttpReads][read] - Email not verified"
           )
-          // $COVERAGE-ON$
           Right(EmailNotVerified)
         case status =>
-          // $COVERAGE-OFF$
-          Logger.warn(
+          logWarn(
             s"[GetEmailVerificationStateHttpParser][GetEmailVerificationStateHttpReads][read] - " +
               s"Unexpected Response, Status $status returned, with response: ${response.body}"
           )
-          // $COVERAGE-ON$
           Left(GetEmailVerificationStateErrorResponse(status, response.body))
       }
   }

--- a/app/connectors/httpParsers/UpdateEmailHttpParser.scala
+++ b/app/connectors/httpParsers/UpdateEmailHttpParser.scala
@@ -18,9 +18,9 @@ package connectors.httpParsers
 
 import models.errors.ErrorModel
 import models.customerInformation.UpdateEmailSuccess
-import play.api.Logger
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK}
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+import utils.LoggerUtil.{logDebug, logWarn}
 
 object UpdateEmailHttpParser {
 
@@ -31,25 +31,19 @@ object UpdateEmailHttpParser {
       response.status match {
         case OK => response.json.validate[UpdateEmailSuccess].fold(
           invalid => {
-            // $COVERAGE-OFF$
-            Logger.warn(s"[UpdateEmailHttpParser][read] - Invalid JSON: $invalid")
-            // $COVERAGE-ON$
+            logWarn(s"[UpdateEmailHttpParser][read] - Invalid JSON: $invalid")
             Left(ErrorModel(INTERNAL_SERVER_ERROR, "The endpoint returned invalid JSON."))
           },
           valid => {
-            // $COVERAGE-OFF$
-            Logger.debug("[UpdateEmailHttpParser][read] - Successfully parsed email update response.")
-            // $COVERAGE-ON$
+            logDebug("[UpdateEmailHttpParser][read] - Successfully parsed email update response.")
             Right(valid)
           }
         )
         case status =>
-          // $COVERAGE-OFF$
-          Logger.warn(
+          logWarn(
             s"[UpdateEmailHttpParser][read] - " +
               s"Unexpected Response, Status $status returned, with response: ${response.body}"
           )
-          // $COVERAGE-ON$
           Left(ErrorModel(status, response.body))
       }
     }

--- a/app/controllers/ConfirmEmailController.scala
+++ b/app/controllers/ConfirmEmailController.scala
@@ -24,9 +24,9 @@ import config.{AppConfig, ErrorHandler}
 import controllers.predicates.{AuthPredicate, InFlightPPOBPredicate}
 import models.User
 import models.customerInformation.UpdateEmailSuccess
-import play.api.Logger
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.VatSubscriptionService
+import utils.LoggerUtil.logInfo
 import views.html.ConfirmEmailView
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -76,7 +76,7 @@ class ConfirmEmailController @Inject()(val authenticate: AuthPredicate,
         }
 
       case _ =>
-        Logger.info("[ConfirmEmailController][updateEmailAddress] no email address found in session")
+        logInfo("[ConfirmEmailController][updateEmailAddress] no email address found in session")
         Future.successful(Redirect(controllers.routes.CaptureEmailController.show()))
     }
   }

--- a/app/controllers/EmailChangeSuccessController.scala
+++ b/app/controllers/EmailChangeSuccessController.scala
@@ -21,9 +21,9 @@ import audit.models.ContactPreferenceAuditModel
 import config.AppConfig
 import controllers.predicates.AuthPredicate
 import javax.inject.{Inject, Singleton}
-import play.api.Logger
 import play.api.mvc._
 import services.ContactPreferenceService
+import utils.LoggerUtil.logWarn
 import views.html.EmailChangeSuccessView
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -53,7 +53,7 @@ class EmailChangeSuccessController @Inject()(val authenticate: AuthPredicate,
           Ok(emailChangeSuccessView(Some(preference.preference)))
 
         case Left(error) =>
-          Logger.warn("[EmailChangeSuccessController][show] Error retrieved from contactPreferenceService." +
+          logWarn("[EmailChangeSuccessController][show] Error retrieved from contactPreferenceService." +
             s" Error code: ${error.status}, Error message: ${error.message}")
           Ok(emailChangeSuccessView())
 

--- a/app/controllers/VerifyEmailController.scala
+++ b/app/controllers/VerifyEmailController.scala
@@ -21,9 +21,9 @@ import config.{AppConfig, ErrorHandler}
 import controllers.predicates.{AuthPredicate, InFlightPPOBPredicate}
 import javax.inject.{Inject, Singleton}
 import models.User
-import play.api.Logger
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.EmailVerificationService
+import utils.LoggerUtil.logWarn
 import views.html.VerifyEmailView
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -53,7 +53,7 @@ class VerifyEmailController @Inject()(val authenticate: AuthPredicate,
         emailVerificationService.createEmailVerificationRequest(email, routes.ConfirmEmailController.updateEmailAddress().url).map{
           case Some(true) => Redirect(routes.VerifyEmailController.show())
           case Some(false) =>
-            Logger.warn(
+            logWarn(
               "[VerifyEmailController][sendVerification] - " +
                 "Unable to send email verification request. Service responded with 'already verified'"
             )

--- a/app/controllers/predicates/AuthoriseAsAgentWithClient.scala
+++ b/app/controllers/predicates/AuthoriseAsAgentWithClient.scala
@@ -25,6 +25,7 @@ import play.api.mvc._
 import services.EnrolmentsAuthService
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve._
+import utils.LoggerUtil.{logDebug, logWarn}
 import views.html.errors.SessionTimeoutView
 import views.html.errors.agent.{AgentJourneyDisabledView, NotAuthorisedForClientView}
 
@@ -54,7 +55,7 @@ class AuthoriseAsAgentWithClient @Inject()(enrolmentsAuthService: EnrolmentsAuth
     if (appConfig.features.agentAccessEnabled()) {
       request.session.get(SessionKeys.clientVrn) match {
         case Some(vrn) =>
-          Logger.debug(s"[AuthoriseAsAgentWithClient][invokeBlock] - Client VRN from Session: $vrn")
+          logDebug(s"[AuthoriseAsAgentWithClient][invokeBlock] - Client VRN from Session: $vrn")
           enrolmentsAuthService.authorised(delegatedAuthRule(vrn))
             .retrieve(v2.Retrievals.affinityGroup and v2.Retrievals.allEnrolments) {
               case None ~ _ =>
@@ -65,12 +66,12 @@ class AuthoriseAsAgentWithClient @Inject()(enrolmentsAuthService: EnrolmentsAuth
                 block(user)
             } recover {
               case _: NoActiveSession =>
-                Logger.debug(s"[AuthoriseAsAgentWithClient][invokeBlock] - Agent does not have an active session, " +
+                logDebug(s"[AuthoriseAsAgentWithClient][invokeBlock] - Agent does not have an active session, " +
                   s"rendering Session Timeout")
                 Unauthorized(sessionTimeoutView())
 
               case _: AuthorisationException =>
-                Logger.warn(s"[AuthoriseAsAgentWithClient][invokeBlock] - Agent does not have " +
+                logWarn(s"[AuthoriseAsAgentWithClient][invokeBlock] - Agent does not have " +
                   s"delegated authority for Client")
                 Ok(notAuthorisedForClientView(vrn))
 

--- a/app/utils/LoggerUtil.scala
+++ b/app/utils/LoggerUtil.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import play.api.Logger
+
+// $COVERAGE-OFF$
+
+object LoggerUtil {
+
+  def logInfo(content: String): Unit = Logger.info(content)
+  def logDebug(content: String): Unit = Logger.debug(content)
+  def logWarn(content: String): Unit = Logger.warn(content)
+  def logError(content: String): Unit = Logger.error(content)
+}
+
+// $COVERAGE-ON$


### PR DESCRIPTION
This utility bypasses the scoverage issue regarding Play Logger statements being incorrectly reported as untested. This protects our overall test coverage from dropping and bypasses the need to add individual coverage statements before and after each log line.