### PR TITLE
BTAT-5865 Added support for conflict response from update email request

### DIFF
--- a/app/controllers/predicates/InFlightPPOBPredicate.scala
+++ b/app/controllers/predicates/InFlightPPOBPredicate.scala
@@ -20,7 +20,6 @@ import javax.inject.{Inject, Singleton}
 import common.SessionKeys.inFlightContactDetailsChangeKey
 import config.{AppConfig, ErrorHandler}
 import models.User
-import play.api.Logger
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{ActionRefiner, MessagesControllerComponents, Result}
 import play.api.mvc.Results.{Ok, Redirect}

--- a/app/services/VatSubscriptionService.scala
+++ b/app/services/VatSubscriptionService.scala
@@ -48,11 +48,7 @@ class VatSubscriptionService @Inject()(connector: VatSubscriptionConnector, emai
     emailVerificationService.isEmailVerified(email) flatMap {
       case Some(true) =>
         this.getCustomerInfo(vrn) flatMap {
-          case Right(customerInfo) =>
-            connector.updateEmail(vrn, buildEmailUpdateModel(email, customerInfo.ppob)) map {
-              case Right(success) => Right(success)
-              case Left(error) => Left(error)
-            }
+          case Right(customerInfo) => connector.updateEmail(vrn, buildEmailUpdateModel(email, customerInfo.ppob))
           case Left(error) => Future.successful(Left(error))
         }
       case Some(false) => Future.successful(Right(UpdateEmailSuccess("")))

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -50,7 +50,7 @@
 
     <logger name="uk.gov" level="OFF"/>
 
-    <logger name="application" level="ERROR"/>
+    <logger name="application" level="DEBUG"/>
 
     <logger name="connector" level="ERROR">
         <appender-ref ref="STDOUT"/>

--- a/test/controllers/ConfirmEmailControllerSpec.scala
+++ b/test/controllers/ConfirmEmailControllerSpec.scala
@@ -17,15 +17,13 @@
 package controllers
 
 import assets.BaseTestConstants.vrn
-import common.SessionKeys
 import models.User
 import models.customerInformation.UpdateEmailSuccess
 import models.errors.ErrorModel
 import org.jsoup.Jsoup
 import play.api.http.Status
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, CONFLICT}
-import play.api.mvc.{AnyContent, AnyContentAsEmpty}
-import play.api.test.FakeRequest
+import play.api.mvc.AnyContent
 import play.api.test.Helpers._
 import views.html.ConfirmEmailView
 
@@ -43,9 +41,6 @@ class ConfirmEmailControllerSpec extends ControllerBaseSpec  {
     injector.instanceOf[ConfirmEmailView],
     mockConfig
   )
-
-  lazy val requestWithEmail: FakeRequest[AnyContentAsEmpty.type] =
-    request.withSession(SessionKeys.emailKey -> testEmail)
 
   "Calling the extractEmail function in ConfirmEmailController" when {
 
@@ -85,12 +80,11 @@ class ConfirmEmailControllerSpec extends ControllerBaseSpec  {
 
     "the user is not authorised" should {
 
-      "show an internal server error" in {
-        mockUnauthorised()
+      "return forbidden (403)" in {
+        mockIndividualWithoutEnrolment()
         val result = TestConfirmEmailController.show(requestWithEmail)
 
-        status(result) shouldBe Status.INTERNAL_SERVER_ERROR
-        messages(Jsoup.parse(bodyOf(result)).title) shouldBe "Sorry, we are experiencing technical difficulties - 500"
+        status(result) shouldBe Status.FORBIDDEN
       }
     }
   }
@@ -124,7 +118,7 @@ class ConfirmEmailControllerSpec extends ControllerBaseSpec  {
         }
       }
 
-      "there was an expected error trying to update the email address" should {
+      "there was an unexpected error trying to update the email address" should {
 
         "return an Internal Server Error" in {
           mockIndividualAuthorised()
@@ -158,18 +152,16 @@ class ConfirmEmailControllerSpec extends ControllerBaseSpec  {
 
         status(result) shouldBe Status.SEE_OTHER
         redirectLocation(result) shouldBe Some("/vat-through-software/account/correspondence/change-email-address")
-
       }
     }
 
     "the user is not authorised" should {
 
-      "return an Internal Server Error" in {
-        mockUnauthorised()
+      "return forbidden (403)" in {
+        mockIndividualWithoutEnrolment()
         val result = TestConfirmEmailController.updateEmailAddress()(requestWithEmail)
 
-        status(result) shouldBe Status.INTERNAL_SERVER_ERROR
-        messages(Jsoup.parse(bodyOf(result)).title) shouldBe "Sorry, we are experiencing technical difficulties - 500"
+        status(result) shouldBe Status.FORBIDDEN
       }
     }
   }

--- a/test/controllers/predicates/AuthPredicateSpec.scala
+++ b/test/controllers/predicates/AuthPredicateSpec.scala
@@ -73,13 +73,13 @@ class AuthPredicateSpec extends MockAuth with MaterializerSupport {
             }
           }
 
-          "an unauthorised result is returned from Auth" should {
+          "an authorisation exception is returned from Auth" should {
 
             mockConfig.features.agentAccessEnabled(true)
             lazy val result = await(target(fakeRequestWithClientsVRN))
 
             "return Internal Server Error (500)" in {
-              mockUnauthorised()
+              mockAuthorisationException()
               status(result) shouldBe Status.INTERNAL_SERVER_ERROR
             }
 

--- a/test/controllers/predicates/AuthoriseAsAgentWithClientSpec.scala
+++ b/test/controllers/predicates/AuthoriseAsAgentWithClientSpec.scala
@@ -63,7 +63,7 @@ class AuthoriseAsAgentWithClientSpec extends MockAuth {
         lazy val result = target(fakeRequestWithClientsVRN)
 
         "return 200" in {
-          mockUnauthorised()
+          mockAuthorisationException()
           status(result) shouldBe Status.OK
         }
 

--- a/test/mocks/MockAuth.scala
+++ b/test/mocks/MockAuth.scala
@@ -168,7 +168,6 @@ trait MockAuth extends TestUtil with BeforeAndAfterEach with MockitoSugar with M
   def mockMissingBearerToken()(): OngoingStubbing[Future[~[Option[AffinityGroup], Enrolments]]] =
     setupAuthResponse(Future.failed(MissingBearerToken()))
 
-  def mockUnauthorised()(): OngoingStubbing[Future[~[Option[AffinityGroup], Enrolments]]] =
+  def mockAuthorisationException()(): OngoingStubbing[Future[~[Option[AffinityGroup], Enrolments]]] =
     setupAuthResponse(Future.failed(InsufficientEnrolments()))
-
 }

--- a/test/utils/TestUtil.scala
+++ b/test/utils/TestUtil.scala
@@ -52,6 +52,8 @@ trait TestUtil extends UnitSpec with GuiceOneAppPerSuite with MaterializerSuppor
   val testEmail = "test@email.co.uk"
 
   implicit lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+  lazy val requestWithEmail: FakeRequest[AnyContentAsEmpty.type] =
+    request.withSession(SessionKeys.emailKey -> testEmail)
 
   lazy val fakeRequestWithClientsVRN: FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest().withSession(SessionKeys.clientVrn -> vrn)


### PR DESCRIPTION
As part of this PR I also corrected a few test cases that were mocking the wrong kind of unauthorised scenario. They were testing for an unauthorised user (i.e. non-MTD enrolments) but the mock was throwing an AuthorisationException, causing a generic error.

I also turned on debug logging locally as it was set to ERROR and not logging anything when the app was being run.