### PR TITLE
BTAT-6274 Updated agent predicate to redirect to VACLF

### DIFF
--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -48,7 +48,6 @@ trait AppConfig {
   val signInContinueUrl: String
   val agentInvitationsFastTrack: String
   val govUkCommercialSoftware: String
-  val vatAgentClientLookupServiceUrl: String
   val vatAgentClientLookupServicePath: String
   val features: Features
   val emailVerificationBaseUrl: String
@@ -119,8 +118,9 @@ class FrontendAppConfig @Inject()(configuration: Configuration, sc: ServicesConf
 
   private lazy val host: String = sc.getString(Keys.host)
 
-  override val vatAgentClientLookupServiceUrl: String = sc.getString(Keys.vatAgentClientLookupServiceUrl)
-  override val vatAgentClientLookupServicePath: String = sc.getString(Keys.vatAgentClientLookupServicePath)
+  private val vatAgentClientLookupServiceUrl: String = sc.getString(Keys.vatAgentClientLookupServiceUrl)
+  override val vatAgentClientLookupServicePath: String =
+    vatAgentClientLookupServiceUrl + sc.getString(Keys.vatAgentClientLookupServicePath)
   override val vatSubscriptionHost: String = sc.baseUrl(Keys.vatSubscription)
 
   override val manageVatSubscriptionServiceUrl: String = sc.getString(Keys.manageVatSubscriptionServiceUrl)

--- a/app/controllers/predicates/AuthoriseAsAgentWithClient.scala
+++ b/app/controllers/predicates/AuthoriseAsAgentWithClient.scala
@@ -77,8 +77,7 @@ class AuthoriseAsAgentWithClient @Inject()(enrolmentsAuthService: EnrolmentsAuth
 
             }
         case _ =>
-          //TODO redirect to VALCUFE with query string for redirectURL
-          Future.successful(errorHandler.showInternalServerError)
+          Future.successful(Redirect(appConfig.vatAgentClientLookupServicePath))
       }
     } else {
       Future.successful(Unauthorized(agentJourneyDisabledView()))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -161,7 +161,7 @@ agent-invitations-fast-track {
 
 vat-agent-client-lookup-frontend {
   url = "http://localhost:9149"
-  path = "/vat-through-software/agent-lookup/client-vat-number"
+  path = "/vat-through-software/representative/client-vat-number"
 }
 
 manage-vat-subscription-frontend {

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -44,7 +44,6 @@ class MockAppConfig(val runModeConfiguration: Configuration, val mode: Mode = Mo
   override val agentInvitationsFastTrack: String = "/agent-invitations-frontend"
   override val govUkCommercialSoftware: String = "https://www.gov.uk/guidance/use-software-to-submit-your-vat-returns"
   override val vatAgentClientLookupServicePath: String = ""
-  override val vatAgentClientLookupServiceUrl: String = ""
   override val features: Features = new Features(runModeConfiguration)
   override val emailVerificationBaseUrl: String = "mockEmailBaseUrl"
   override val manageVatSubscriptionServiceUrl: String = ""


### PR DESCRIPTION
I've not provided a redirect URL for VACLF - this is because when agent access goes live, the VACLF journey will have been updated to not use redirect URLs.

**Note:** please could you make sure this is merged too https://github.com/hmrc/app-config-base/pull/2353