### PR TITLE
BTAT-6275 Updated AuthPredicate to block agents only for specific routes

### DIFF
--- a/app/controllers/BaseController.scala
+++ b/app/controllers/BaseController.scala
@@ -16,8 +16,14 @@
 
 package controllers
 
+import controllers.predicates.{AuthPredicate, AuthPredicateComponents}
 import play.api.i18n.I18nSupport
 import play.api.mvc.MessagesControllerComponents
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
-abstract class BaseController(val mcc: MessagesControllerComponents) extends FrontendController(mcc) with I18nSupport
+abstract class BaseController(val mcc: MessagesControllerComponents,
+                              authComps: AuthPredicateComponents) extends FrontendController(mcc) with I18nSupport {
+
+  val allowAgentPredicate = new AuthPredicate(authComps, allowsAgents = true)
+  val blockAgentPredicate = new AuthPredicate(authComps, allowsAgents = false)
+}

--- a/app/controllers/CaptureEmailController.scala
+++ b/app/controllers/CaptureEmailController.scala
@@ -20,7 +20,7 @@ import audit.AuditingService
 import audit.models.AttemptedEmailAddressAuditModel
 import common.SessionKeys
 import config.{AppConfig, ErrorHandler}
-import controllers.predicates.{AuthPredicate, InFlightPPOBPredicate}
+import controllers.predicates.{AuthPredicateComponents, InFlightPPOBPredicate}
 import forms.EmailForm._
 import javax.inject.{Inject, Singleton}
 import play.api.mvc._
@@ -30,18 +30,18 @@ import views.html.CaptureEmailView
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class CaptureEmailController @Inject()(val authenticate: AuthPredicate,
+class CaptureEmailController @Inject()(val authComps: AuthPredicateComponents,
                                        val inflightCheck: InFlightPPOBPredicate,
                                        override val mcc: MessagesControllerComponents,
                                        val vatSubscriptionService: VatSubscriptionService,
                                        val errorHandler: ErrorHandler,
                                        val auditService: AuditingService,
                                        captureEmailView: CaptureEmailView,
-                                       implicit val appConfig: AppConfig) extends BaseController(mcc) {
+                                       implicit val appConfig: AppConfig) extends BaseController(mcc, authComps) {
 
   implicit val ec: ExecutionContext = mcc.executionContext
 
-  def show: Action[AnyContent] = (authenticate andThen inflightCheck).async { implicit user =>
+  def show: Action[AnyContent] = (blockAgentPredicate andThen inflightCheck).async { implicit user =>
     val validationEmail: Future[Option[String]] = user.session.get(SessionKeys.validationEmailKey) match {
       case Some(email) => Future.successful(Some(email))
       case _ =>
@@ -69,7 +69,7 @@ class CaptureEmailController @Inject()(val authenticate: AuthPredicate,
     }
   }
 
-  def submit: Action[AnyContent] = (authenticate andThen inflightCheck).async { implicit user =>
+  def submit: Action[AnyContent] = (blockAgentPredicate andThen inflightCheck).async { implicit user =>
     val validationEmail: Option[String] = user.session.get(SessionKeys.validationEmailKey)
     val prepopulationEmail: Option[String] = user.session.get(SessionKeys.emailKey)
 

--- a/app/controllers/EmailChangeSuccessController.scala
+++ b/app/controllers/EmailChangeSuccessController.scala
@@ -19,7 +19,7 @@ package controllers
 import audit.AuditingService
 import audit.models.ContactPreferenceAuditModel
 import config.AppConfig
-import controllers.predicates.AuthPredicate
+import controllers.predicates.{AuthPredicate, AuthPredicateComponents}
 import javax.inject.{Inject, Singleton}
 import play.api.mvc._
 import services.ContactPreferenceService
@@ -29,16 +29,16 @@ import views.html.EmailChangeSuccessView
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class EmailChangeSuccessController @Inject()(val authenticate: AuthPredicate,
+class EmailChangeSuccessController @Inject()(val authComps: AuthPredicateComponents,
                                              override val mcc: MessagesControllerComponents,
                                              auditService: AuditingService,
                                              contactPreferenceService: ContactPreferenceService,
                                              emailChangeSuccessView: EmailChangeSuccessView,
-                                             implicit val appConfig: AppConfig) extends BaseController(mcc) {
+                                             implicit val appConfig: AppConfig) extends BaseController(mcc, authComps) {
 
   implicit val ec: ExecutionContext = mcc.executionContext
 
-  def show: Action[AnyContent] = authenticate.async { implicit user =>
+  def show: Action[AnyContent] = blockAgentPredicate.async { implicit user =>
     if (appConfig.features.contactPreferencesEnabled()) {
 
       contactPreferenceService.getContactPreference(user.vrn) map {

--- a/app/controllers/LanguageController.scala
+++ b/app/controllers/LanguageController.scala
@@ -18,12 +18,13 @@ package controllers
 
 import javax.inject.{Inject, Singleton}
 import config.AppConfig
-import play.api.i18n.Lang
+import play.api.i18n.{I18nSupport, Lang}
 import play.api.mvc.{Action, AnyContent, Flash, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
 @Singleton
 class LanguageController @Inject()(val appConfig: AppConfig,
-                                   override val mcc: MessagesControllerComponents) extends BaseController(mcc) {
+                                   val mcc: MessagesControllerComponents) extends FrontendController(mcc) with I18nSupport {
 
   def languageMap: Map[String, Lang] = appConfig.languageMap
 

--- a/app/controllers/SignOutController.scala
+++ b/app/controllers/SignOutController.scala
@@ -19,10 +19,11 @@ package controllers
 import com.google.inject.{Inject, Singleton}
 import config.AppConfig
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
 @Singleton
-class SignOutController @Inject()(override val mcc: MessagesControllerComponents,
-                                  implicit val appConfig: AppConfig) extends BaseController(mcc) {
+class SignOutController @Inject()(val mcc: MessagesControllerComponents,
+                                  implicit val appConfig: AppConfig) extends FrontendController(mcc) {
 
   def signOut(feedbackOnSignOut: Boolean): Action[AnyContent] = Action { implicit request =>
     val redirectUrl: String = if(feedbackOnSignOut) appConfig.feedbackSignOutUrl else appConfig.unauthorisedSignOutUrl

--- a/app/controllers/predicates/AuthBasePredicate.scala
+++ b/app/controllers/predicates/AuthBasePredicate.scala
@@ -17,11 +17,12 @@
 package controllers.predicates
 
 import common.EnrolmentKeys
-import controllers.BaseController
+import play.api.i18n.I18nSupport
 import play.api.mvc.MessagesControllerComponents
 import uk.gov.hmrc.auth.core.AffinityGroup
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
-abstract class AuthBasePredicate(override val mcc: MessagesControllerComponents) extends BaseController(mcc) {
+abstract class AuthBasePredicate(val mcc: MessagesControllerComponents) extends FrontendController(mcc) with I18nSupport {
 
   def isAgent(group: AffinityGroup): Boolean = group.toString.contains(EnrolmentKeys.agentAffinityGroup)
 

--- a/app/controllers/predicates/AuthPredicateComponents.scala
+++ b/app/controllers/predicates/AuthPredicateComponents.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.predicates
+
+import config.{AppConfig, ErrorHandler}
+import javax.inject.{Inject, Singleton}
+import play.api.mvc.MessagesControllerComponents
+import services.EnrolmentsAuthService
+import views.html.errors.{NotSignedUpView, SessionTimeoutView}
+import views.html.errors.agent.{AgentJourneyDisabledView, UnauthorisedAgentView}
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class AuthPredicateComponents @Inject()(val enrolmentsAuthService: EnrolmentsAuthService,
+                                        val mcc: MessagesControllerComponents,
+                                        val errorHandler: ErrorHandler,
+                                        val authenticateAsAgentWithClient: AuthoriseAsAgentWithClient,
+                                        val sessionTimeoutView: SessionTimeoutView,
+                                        val agentJourneyDisabledView: AgentJourneyDisabledView,
+                                        val unauthorisedAgentView: UnauthorisedAgentView,
+                                        val notSignedUpView: NotSignedUpView,
+                                        val appConfig: AppConfig,
+                                        val executionContext: ExecutionContext)

--- a/app/testOnly/controllers/FeatureSwitchController.scala
+++ b/app/testOnly/controllers/FeatureSwitchController.scala
@@ -19,14 +19,14 @@ package testOnly.controllers
 import config.AppConfig
 import forms.FeatureSwitchForm
 import javax.inject.Inject
-import controllers.BaseController
 import models.FeatureSwitchModel
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import testOnly.views.html.FeatureSwitch
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
-class FeatureSwitchController @Inject()(override val mcc: MessagesControllerComponents,
+class FeatureSwitchController @Inject()(val mcc: MessagesControllerComponents,
                                         featureSwitchView: FeatureSwitch,
-                                        implicit val appConfig: AppConfig) extends BaseController(mcc) {
+                                        implicit val appConfig: AppConfig) extends FrontendController(mcc) {
 
   def featureSwitch: Action[AnyContent] = Action { implicit request =>
     Ok(featureSwitchView(FeatureSwitchForm.form.fill(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -118,7 +118,7 @@ auditing {
 }
 
 features {
-  agentAccess.enabled = false
+  agentAccess.enabled = true
   emailVerification.enabled = true
   stubContactPreferences.enabled = true
   contactPreferences.enabled = true

--- a/test/controllers/CaptureEmailControllerSpec.scala
+++ b/test/controllers/CaptureEmailControllerSpec.scala
@@ -69,7 +69,7 @@ class CaptureEmailControllerSpec extends ControllerBaseSpec {
     setup(result)
 
     new CaptureEmailController(
-      mockAuthPredicate,
+      mockAuthPredicateComponents,
       mockInflightPPOBPredicate,
       mcc,
       mockVatSubscriptionService,
@@ -216,7 +216,7 @@ class CaptureEmailControllerSpec extends ControllerBaseSpec {
 
         setup(Right(customerInfoResult))
         new CaptureEmailController(
-          mockAuthPredicate,
+          mockAuthPredicateComponents,
           mockInflightPPOBPredicate,
           mcc,
           mockVatSubscriptionService,

--- a/test/controllers/ConfirmEmailControllerSpec.scala
+++ b/test/controllers/ConfirmEmailControllerSpec.scala
@@ -32,7 +32,7 @@ import scala.concurrent.Future
 class ConfirmEmailControllerSpec extends ControllerBaseSpec  {
 
   object TestConfirmEmailController extends ConfirmEmailController(
-    mockAuthPredicate,
+    mockAuthPredicateComponents,
     mockInflightPPOBPredicate,
     mcc,
     mockErrorHandler,

--- a/test/controllers/EmailChangeSuccessControllerSpec.scala
+++ b/test/controllers/EmailChangeSuccessControllerSpec.scala
@@ -36,7 +36,7 @@ class EmailChangeSuccessControllerSpec extends ControllerBaseSpec with MockConta
   val view: EmailChangeSuccessView = injector.instanceOf[EmailChangeSuccessView]
 
   object TestController extends EmailChangeSuccessController(
-    mockAuthPredicate,
+    mockAuthPredicateComponents,
     mcc,
     mockAuditingService,
     mockContactPreferenceService,

--- a/test/controllers/VerifyEmailControllerSpec.scala
+++ b/test/controllers/VerifyEmailControllerSpec.scala
@@ -28,7 +28,7 @@ import views.html.VerifyEmailView
 class VerifyEmailControllerSpec extends ControllerBaseSpec with MockEmailVerificationService {
 
   object TestVerifyEmailController extends VerifyEmailController(
-    mockAuthPredicate,
+    mockAuthPredicateComponents,
     mockInflightPPOBPredicate,
     mcc,
     mockEmailVerificationService,

--- a/test/controllers/predicates/AuthPredicateSpec.scala
+++ b/test/controllers/predicates/AuthPredicateSpec.scala
@@ -17,97 +17,127 @@
 package controllers.predicates
 
 import assets.BaseTestConstants.internalServerErrorTitle
+import common.SessionKeys
 import mocks.MockAuth
 import org.jsoup.Jsoup
 import play.api.http.Status
 import play.api.mvc.Results.Ok
 import play.api.mvc.{Action, AnyContent}
+import play.api.test.FakeRequest
 import utils.MaterializerSupport
 
 import scala.concurrent.Future
 
 class AuthPredicateSpec extends MockAuth with MaterializerSupport {
 
-  def target: Action[AnyContent] = mockAuthPredicate.async {
+  val allowAgentPredicate: Action[AnyContent] = mockAuthPredicate.async {
     implicit request => Future.successful(Ok("test"))
   }
 
   "The AuthPredicateSpec" when {
 
-    "agent access is enabled" when {
+    "the user is an Agent" when {
 
-      "the user does not have affinity group" should {
+      "the Agent has an active HMRC-AS-AGENT enrolment" when {
 
-        "return ISE (500)" in {
-          mockConfig.features.agentAccessEnabled(true)
-          mockUserWithoutAffinity()
-          status(target(request)) shouldBe Status.INTERNAL_SERVER_ERROR
-        }
-      }
+        "the agent access feature is enabled" when {
 
-      "the user is an Agent" when {
-
-
-        "the Agent has an Active HMRC-AS-AGENT enrolment" when {
-
-          "a successful authorisation result is returned from Auth" should {
+          "the allowAgents parameter is set to true" should {
 
             "return OK (200)" in {
               mockConfig.features.agentAccessEnabled(true)
               mockAgentAuthorised()
-              status(target(fakeRequestWithClientsVRN)) shouldBe Status.OK
+              status(allowAgentPredicate(fakeRequestWithClientsVRN)) shouldBe Status.OK
             }
           }
 
-          "a no active session result is returned from Auth" should {
+          "the allowAgents parameter is set to false" should {
 
-            mockConfig.features.agentAccessEnabled(true)
-            lazy val result = await(target(fakeRequestWithClientsVRN))
+            val blockAgentPredicate: Action[AnyContent] =
+              new AuthPredicate(mockAuthPredicateComponents, allowsAgents = false).async {
+                implicit request => Future.successful(Ok("test"))
+              }
 
-            "return Unauthorised (401)" in {
-              mockMissingBearerToken()
+            lazy val result = await(blockAgentPredicate(fakeRequestWithClientsVRN))
+
+            "return Unauthorized (401)" in {
+              mockAgentAuthorised()
               status(result) shouldBe Status.UNAUTHORIZED
             }
 
-            "render the Unauthorised page" in {
-              messages(Jsoup.parse(bodyOf(result)).title) shouldBe "Your session has timed out"
+            "show the agent journey disabled page" in {
+              messages(Jsoup.parse(bodyOf(result)).title) shouldBe "You cannot change your client’s correspondence details yet"
             }
           }
 
-          "an authorisation exception is returned from Auth" should {
+          "the Agent does NOT have an Active HMRC-AS-AGENT enrolment" should {
 
-            mockConfig.features.agentAccessEnabled(true)
-            lazy val result = await(target(fakeRequestWithClientsVRN))
+            lazy val result = await(allowAgentPredicate(fakeRequestWithClientsVRN))
 
-            "return Internal Server Error (500)" in {
-              mockAuthorisationException()
-              status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+            "return Forbidden" in {
+              mockConfig.features.agentAccessEnabled(true)
+              mockAgentWithoutEnrolment()
+              status(result) shouldBe Status.FORBIDDEN
             }
 
-            "render the Unauthorised page" in {
-              messages(Jsoup.parse(bodyOf(result)).title) shouldBe internalServerErrorTitle
+            "render the Unauthorised Agent page" in {
+              messages(Jsoup.parse(bodyOf(result)).title) shouldBe "You can not use this service yet"
             }
           }
         }
 
-        "the Agent does NOT have an Active HMRC-AS-AGENT enrolment" should {
+        "the agent access feature is disabled" should {
 
-          mockConfig.features.agentAccessEnabled(true)
-          lazy val result = await(target(fakeRequestWithClientsVRN))
+          lazy val result = await(allowAgentPredicate(fakeRequestWithClientsVRN))
 
-          "return Forbidden" in {
-            mockAgentWithoutEnrolment()
-            status(result) shouldBe Status.FORBIDDEN
+          "return Unauthorized (401)" in {
+            mockConfig.features.agentAccessEnabled(false)
+            mockAgentAuthorised()
+            status(result) shouldBe Status.UNAUTHORIZED
           }
 
-          "render the Unauthorised Agent page" in {
-            messages(Jsoup.parse(bodyOf(result)).title) shouldBe "You can not use this service yet"
+          "show the agent journey disabled page" in {
+            messages(Jsoup.parse(bodyOf(result)).title) shouldBe "You cannot change your client’s correspondence details yet"
           }
         }
       }
 
-    }
+      "the agent does not have an affinity group" should {
 
+        "return ISE (500)" in {
+          mockUserWithoutAffinity()
+          status(allowAgentPredicate(request)) shouldBe Status.INTERNAL_SERVER_ERROR
+        }
+      }
+
+      "a no active session result is returned from Auth" should {
+
+        lazy val result = await(allowAgentPredicate(fakeRequestWithClientsVRN))
+
+        "return Unauthorised (401)" in {
+          mockMissingBearerToken()
+          status(result) shouldBe Status.UNAUTHORIZED
+        }
+
+        "render the Unauthorised page" in {
+          messages(Jsoup.parse(bodyOf(result)).title) shouldBe "Your session has timed out"
+        }
+      }
+
+      "an authorisation exception is returned from Auth" should {
+
+        lazy val result = await(allowAgentPredicate(fakeRequestWithClientsVRN))
+
+        "return Internal Server Error (500)" in {
+          mockAuthorisationException()
+          status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+        }
+
+        "render the Unauthorised page" in {
+          messages(Jsoup.parse(bodyOf(result)).title) shouldBe internalServerErrorTitle
+        }
+      }
+    }
 
     "the user is an Individual (Principle Entity)" when {
 
@@ -115,13 +145,13 @@ class AuthPredicateSpec extends MockAuth with MaterializerSupport {
 
         "return OK (200)" in {
           mockIndividualAuthorised()
-          status(target(request)) shouldBe Status.OK
+          status(allowAgentPredicate(request)) shouldBe Status.OK
         }
       }
 
       "they do NOT have an active HMRC-MTD-VAT enrolment" should {
 
-        lazy val result = await(target(request))
+        lazy val result = await(allowAgentPredicate(request))
 
         "return Forbidden (403)" in {
           mockIndividualWithoutEnrolment()
@@ -131,16 +161,6 @@ class AuthPredicateSpec extends MockAuth with MaterializerSupport {
         "render the Not Signed Up page" in {
           messages(Jsoup.parse(bodyOf(result)).title) shouldBe "You can not use this service yet"
         }
-      }
-    }
-
-    "agent access is disabled" should {
-      "show agent journey disabled page" in {
-        mockConfig.features.agentAccessEnabled(false)
-        mockAgentAuthorised()
-        val result = target(request)
-        status(result) shouldBe Status.UNAUTHORIZED
-        messages(Jsoup.parse(bodyOf(result)).title) shouldBe "You cannot change your client’s correspondence details yet"
       }
     }
   }

--- a/test/controllers/predicates/AuthoriseAsAgentWithClientSpec.scala
+++ b/test/controllers/predicates/AuthoriseAsAgentWithClientSpec.scala
@@ -36,87 +36,70 @@ class AuthoriseAsAgentWithClientSpec extends MockAuth {
 
   "The AuthoriseAsAgentWithClientSpec" when {
 
-    "the agent access is enabled" when {
-      "the agent is authorised with a Client VRN in session" should {
+    "the agent is authorised with a Client VRN in session" should {
 
-        "return 200" in {
-          mockConfig.features.agentAccessEnabled(true)
-
-          mockAgentAuthorised()
-          val result = target(fakeRequestWithClientsVRN)
-          status(result) shouldBe Status.OK
-        }
-      }
-
-      "the agent is not authenticated" should {
-
-        "return 401 (Unauthorised)" in {
-          mockConfig.features.agentAccessEnabled(true)
-
-          mockMissingBearerToken()
-          val result = target(fakeRequestWithClientsVRN)
-          status(result) shouldBe Status.UNAUTHORIZED
-        }
-      }
-
-      "the agent is not authorised" should {
-
+      "return 200" in {
         mockConfig.features.agentAccessEnabled(true)
-        lazy val result = target(fakeRequestWithClientsVRN)
 
-        "return 200" in {
-          mockAuthorisationException()
-          status(result) shouldBe Status.OK
-        }
-
-        "page title is correct" in {
-          messages(Jsoup.parse(bodyOf(result)).title) shouldBe "You are not authorised for this client"
-        }
-      }
-
-      "the agent has no enrolments" should {
-
-        mockConfig.features.agentAccessEnabled(true)
-        lazy val result = await(target(fakeRequestWithClientsVRN))
-
-        "return Internal Server Error (500)" in {
-          mockAgentWithoutAffinity()
-          status(result) shouldBe Status.INTERNAL_SERVER_ERROR
-        }
-
-        "render the Internal Server Error page" in {
-          messages(Jsoup.parse(bodyOf(result)).title) shouldBe internalServerErrorTitle
-        }
-      }
-
-      "there is no client VRN in session" should {
-
-        mockConfig.features.agentAccessEnabled(true)
         mockAgentAuthorised()
-        lazy val result = await(target(request))
-
-        "return 303" in {
-          status(result) shouldBe Status.SEE_OTHER
-        }
-
-        "redirect to the agent client lookup service" in {
-          redirectLocation(result) shouldBe Some(mockConfig.vatAgentClientLookupServicePath)
-        }
+        val result = target(fakeRequestWithClientsVRN)
+        status(result) shouldBe Status.OK
       }
     }
 
-    "agent access is disabled" should {
+    "the agent is not authenticated" should {
 
-      mockConfig.features.agentAccessEnabled(false)
-      mockAgentAuthorised()
-      val result = target(request)
+      "return 401 (Unauthorised)" in {
+        mockConfig.features.agentAccessEnabled(true)
 
-      "return unauthorised" in {
+        mockMissingBearerToken()
+        val result = target(fakeRequestWithClientsVRN)
         status(result) shouldBe Status.UNAUTHORIZED
       }
+    }
 
-      "show the correct title" in {
-        messages(Jsoup.parse(bodyOf(result)).title) shouldBe "You cannot change your client’s correspondence details yet"
+    "the agent is not authorised" should {
+
+      mockConfig.features.agentAccessEnabled(true)
+      lazy val result = target(fakeRequestWithClientsVRN)
+
+      "return 200" in {
+        mockAuthorisationException()
+        status(result) shouldBe Status.OK
+      }
+
+      "page title is correct" in {
+        messages(Jsoup.parse(bodyOf(result)).title) shouldBe "You are not authorised for this client"
+      }
+    }
+
+    "the agent has no enrolments" should {
+
+      mockConfig.features.agentAccessEnabled(true)
+      lazy val result = await(target(fakeRequestWithClientsVRN))
+
+      "return Internal Server Error (500)" in {
+        mockAgentWithoutAffinity()
+        status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+      }
+
+      "render the Internal Server Error page" in {
+        messages(Jsoup.parse(bodyOf(result)).title) shouldBe internalServerErrorTitle
+      }
+    }
+
+    "there is no client VRN in session" should {
+
+      mockConfig.features.agentAccessEnabled(true)
+      mockAgentAuthorised()
+      lazy val result = await(target(request))
+
+      "return 303" in {
+        status(result) shouldBe Status.SEE_OTHER
+      }
+
+      "redirect to the agent client lookup service" in {
+        redirectLocation(result) shouldBe Some(mockConfig.vatAgentClientLookupServicePath)
       }
     }
   }

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -67,6 +67,5 @@ class MockAppConfig(val runModeConfiguration: Configuration, val mode: Mode = Mo
   override val timeoutCountdown: Int = 999
   override val contactPreferencesService: String = ""
   override def contactPreferencesUrl(vrn: String): String = s"contact-preferences/vat/vrn/$vrn"
-
   override val contactHmrcUrl: String = "mockRemoveEmailUrl"
 }

--- a/test/mocks/MockAuth.scala
+++ b/test/mocks/MockAuth.scala
@@ -71,18 +71,22 @@ trait MockAuth extends TestUtil with BeforeAndAfterEach with MockitoSugar with M
       ec
     )
 
+  val mockAuthPredicateComponents = new AuthPredicateComponents(
+    mockEnrolmentsAuthService,
+    mcc,
+    mockErrorHandler,
+    mockAuthAsAgentWithClient,
+    sessionTimeoutView,
+    agentJourneyDisabledView,
+    unauthorisedAgentView,
+    notSignedUpView,
+    mockConfig,
+    ec
+  )
+
   val mockAuthPredicate: AuthPredicate =
     new AuthPredicate(
-      mockEnrolmentsAuthService,
-      mcc,
-      mockErrorHandler,
-      mockAuthAsAgentWithClient,
-      sessionTimeoutView,
-      agentJourneyDisabledView,
-      unauthorisedAgentView,
-      notSignedUpView,
-      mockConfig,
-      ec
+      mockAuthPredicateComponents, allowsAgents = true
     )
 
   val mockInflightPPOBPredicate: InFlightPPOBPredicate = {


### PR DESCRIPTION
Could you also merge this please: https://github.com/hmrc/app-config-base/pull/2353

Agent access has been toggled locally and in the environments but is still set to false in Production.