### PR TITLE
BTAT-4322 Added session key redirect mechanism for email success page

### DIFF
--- a/app/common/SessionKeys.scala
+++ b/app/common/SessionKeys.scala
@@ -23,6 +23,7 @@ object SessionKeys {
 
   val validationEmailKey: String = "vatCorrespondenceValidationEmail"
   val prepopulationEmailKey: String = "vatCorrespondencePrepopulationEmail"
+  val emailChangeSuccessful: String = "vatCorrespondenceEmailChangeSuccessful"
 
   val validationWebsiteKey: String = "vatCorrespondenceValidationWebsite"
   val prepopulationWebsiteKey: String = "vatCorrespondencePrepopulationWebsite"

--- a/app/controllers/email/ConfirmEmailController.scala
+++ b/app/controllers/email/ConfirmEmailController.scala
@@ -18,7 +18,7 @@ package controllers.email
 
 import audit.AuditingService
 import audit.models.ChangedEmailAddressAuditModel
-import common.SessionKeys.{inFlightContactDetailsChangeKey, prepopulationEmailKey, validationEmailKey}
+import common.SessionKeys._
 import config.{AppConfig, ErrorHandler}
 import controllers.predicates.AuthPredicateComponents
 import controllers.BaseController
@@ -76,6 +76,7 @@ class ConfirmEmailController @Inject()(val errorHandler: ErrorHandler,
             )
             Redirect(routes.EmailChangeSuccessController.show())
               .removingFromSession(prepopulationEmailKey, validationEmailKey, inFlightContactDetailsChangeKey)
+              .addingToSession(emailChangeSuccessful -> "true")
 
           case Left(ErrorModel(CONFLICT, _)) =>
             logWarn("[ConfirmEmailController][updateEmailAddress] - There is an email address update request " +

--- a/app/views/email/EmailChangeSuccessView.scala.html
+++ b/app/views/email/EmailChangeSuccessView.scala.html
@@ -28,23 +28,17 @@
 
   <h2 class="heading-medium">@messages("common.whatHappensNext")</h2>
 
-  @if(appConfig.features.contactPreferencesEnabled()) {
+  @preference match {
 
-    @preference match {
-
-      case (Some(ContactPreference.digital)) => {
-        <p id="preference-message">@messages("emailChangeSuccess.helpOne.digitalPreference")</p>
-      }
-      case (Some(ContactPreference.paper)) => {
-        <p id="preference-message">@messages("emailChangeSuccess.helpOne.paperPreference")</p>
-      }
-      case _ => {
-        <p>@messages("common.helpOne.apiFailure")</p>
-      }
+    case (Some(ContactPreference.digital)) => {
+      <p id="preference-message">@messages("emailChangeSuccess.helpOne.digitalPreference")</p>
     }
-
-  } else {
-    <p>@messages("emailChangeSuccess.helpOne")</p>
+    case (Some(ContactPreference.paper)) => {
+      <p id="preference-message">@messages("emailChangeSuccess.helpOne.paperPreference")</p>
+    }
+    case _ => {
+      <p>@messages("common.helpOne.apiFailure")</p>
+    }
   }
 
   <p>@messages("emailChangeSuccess.helpTwo")</p>

--- a/it/pages/email/EmailChangeSuccessPageSpec.scala
+++ b/it/pages/email/EmailChangeSuccessPageSpec.scala
@@ -31,34 +31,29 @@ class EmailChangeSuccessPageSpec extends BasePageISpec {
 
   val successEmailPath = "/email-address-confirmation"
 
-  val session: Map[String, String] = Map(SessionKeys.clientVrn -> clientVRN)
-  lazy val mockAppConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
+  val session: Map[String, String] = Map(SessionKeys.emailChangeSuccessful -> "true")
 
   "Calling the EmailChangeSuccessController.show method" when {
 
-    "the user is authenticated" when {
+    "the user is authenticated and has the email change successful session key" when {
 
-      "there is a user in session" should {
-        def show: WSResponse = get(successEmailPath, session)
+      def show: WSResponse = get(successEmailPath, session)
 
-        "render the success email page" in {
+      "render the success email page" in {
 
-          given.user.isAuthenticated
+        given.user.isAuthenticated
 
-          And("a successful response for an individual is stubbed")
-          ContactPreferencesStub.getContactPrefs(OK, Json.obj("preference" -> "DiGiTaL"))
+        And("a successful response for an individual is stubbed")
+        ContactPreferencesStub.getContactPrefs(OK, Json.obj("preference" -> "DiGiTaL"))
 
-          When("the Confirm email page is called")
-          val result = show
+        When("the Confirm email page is called")
+        val result = show
 
-          result should have(
-            httpStatus(Status.OK),
-            elementText("#preference-message")(Messages("emailChangeSuccess.helpOne.digitalPreference"))
-          )
-        }
-
+        result should have(
+          httpStatus(Status.OK),
+          elementText("#preference-message")(Messages("emailChangeSuccess.helpOne.digitalPreference"))
+        )
       }
     }
   }
-
 }

--- a/test/controllers/email/EmailChangeSuccessControllerSpec.scala
+++ b/test/controllers/email/EmailChangeSuccessControllerSpec.scala
@@ -23,14 +23,14 @@ import mocks.{MockAuditingService, MockContactPreferenceService}
 import models.contactPreferences.ContactPreference
 import models.errors.ErrorModel
 import org.jsoup.Jsoup
-import org.mockito.ArgumentMatchers
-import org.mockito.Mockito.verify
+import org.mockito.Mockito.reset
 import play.api.http.Status
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.http.HeaderCarrier
 import views.html.email.EmailChangeSuccessView
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 class EmailChangeSuccessControllerSpec extends ControllerBaseSpec with MockContactPreferenceService with MockAuditingService {
 
@@ -42,157 +42,121 @@ class EmailChangeSuccessControllerSpec extends ControllerBaseSpec with MockConta
     view
   )
 
+  val successfulChangeRequest: FakeRequest[AnyContentAsEmpty.type] =
+    request.withSession(emailChangeSuccessful -> "true")
+
   "Calling the show action" when {
 
     "a user is enrolled with a valid enrolment" when {
 
-      "a valid response is retrieved from the contact preference service" should {
+      "the user has the email change success key in the session" when {
 
-        "a digital preference is retrieved" should {
-          lazy val result = TestController.show(request.withSession(
-            prepopulationEmailKey -> "myemail@gmail.com",
-            validationEmailKey -> "anotheremail@gmail.com"
-          ))
+        "a valid response is retrieved from the contact preference service" should {
+
+          "a digital preference is retrieved" should {
+
+            lazy val result = {
+              mockIndividualAuthorised()
+              getMockContactPreference("999999999")(Future(Right(ContactPreference("DIGITAL"))))
+              TestController.show(successfulChangeRequest)
+            }
+
+            lazy val document = Jsoup.parse(bodyOf(result))
+
+            "return 200" in {
+              status(result) shouldBe Status.OK
+            }
+
+            "audit the contact preference" in {
+              verifyExtendedAudit(ContactPreferenceAuditModel("999999999", "DIGITAL"))
+              reset(mockAuditingService)
+            }
+
+            "render the email change success page" in {
+              messages(document.select("#content article p:nth-of-type(1)").text()) shouldBe
+                "We will send you an email within 2 working days with an update, followed by a letter to your " +
+                  "principal place of business. You can also go to your HMRC secure messages to find out if your " +
+                  "request has been accepted."
+            }
+          }
+
+          "a paper preference is retrieved" should {
+
+            lazy val result = {
+              mockIndividualAuthorised()
+              getMockContactPreference("999999999")(Future(Right(ContactPreference("PAPER"))))
+              TestController.show(successfulChangeRequest)
+            }
+
+            lazy val document = Jsoup.parse(bodyOf(result))
+
+            "return 200" in {
+              status(result) shouldBe Status.OK
+            }
+
+            "audit the contact preference" in {
+              verifyExtendedAudit(ContactPreferenceAuditModel("999999999", "PAPER"))
+              reset(mockAuditingService)
+            }
+
+            "render the email change success page" in {
+              messages(document.select("#content article p:nth-of-type(1)").text()) shouldBe
+                "We will send a letter to your principal place of business with an update within 15 working days."
+            }
+          }
+        }
+
+        "an invalid response is retrieved from the contact preference service" should {
+
+          lazy val result = {
+            mockIndividualAuthorised()
+            getMockContactPreference("999999999")(Future(Left(ErrorModel(Status.BAD_GATEWAY, "Error"))))
+            TestController.show(successfulChangeRequest)
+          }
 
           lazy val document = Jsoup.parse(bodyOf(result))
 
           "return 200" in {
-            mockConfig.features.contactPreferencesEnabled(true)
-            mockIndividualAuthorised()
-            getMockContactPreference("999999999")(Future(Right(ContactPreference("DIGITAL"))))
             status(result) shouldBe Status.OK
+          }
 
-            verify(mockAuditingService)
-              .extendedAudit(
-                ArgumentMatchers.any[ContactPreferenceAuditModel],
-                ArgumentMatchers.any[String]
-
-              )(
-                ArgumentMatchers.any[HeaderCarrier],
-                ArgumentMatchers.any[ExecutionContext]
-              )
+          "return HTML" in {
+            contentType(result) shouldBe Some("text/html")
+            charset(result) shouldBe Some("utf-8")
           }
 
           "render the email change success page" in {
-            mockIndividualAuthorised()
             messages(document.select("#content article p:nth-of-type(1)").text()) shouldBe
-              "We will send you an email within 2 working days with an update, followed by a letter to your " +
-                "principal place of business. You can also go to your HMRC secure messages to find out if your " +
-                "request has been accepted."
-          }
-        }
-
-        "a paper preference is retrieved" should {
-
-          lazy val result = TestController.show(request.withSession(
-            prepopulationEmailKey -> "myemail@gmail.com",
-            validationEmailKey -> "anotheremail@gmail.com"
-          ))
-
-          lazy val document = Jsoup.parse(bodyOf(result))
-
-          "return 200" in {
-            mockConfig.features.contactPreferencesEnabled(true)
-            mockIndividualAuthorised()
-            getMockContactPreference("999999999")(Future(Right(ContactPreference("PAPER"))))
-            status(result) shouldBe Status.OK
-
-            verify(mockAuditingService)
-              .extendedAudit(
-                ArgumentMatchers.any[ContactPreferenceAuditModel],
-                ArgumentMatchers.any[String]
-
-              )(
-                ArgumentMatchers.any[HeaderCarrier],
-                ArgumentMatchers.any[ExecutionContext]
-              )
-          }
-
-          "render the email change success page" in {
-            mockIndividualAuthorised()
-            messages(document.select("#content article p:nth-of-type(1)").text()) shouldBe
-              "We will send a letter to your principal place of business with an update within 15 working days."
+              "We will send you an update within 15 working days."
           }
         }
       }
 
-      "an invalid response is retrieved from the contact preference service" should {
+      "the user does not have the email change success key in the session" should {
 
-        lazy val result = TestController.show(request)
-
-        lazy val document = Jsoup.parse(bodyOf(result))
-
-        "return 200" in {
+        lazy val result = {
           mockIndividualAuthorised()
-          mockConfig.features.contactPreferencesEnabled(true)
-          getMockContactPreference("999999999")(Future(Left(ErrorModel(Status.BAD_GATEWAY, "Error"))))
-          status(result) shouldBe Status.OK
+          TestController.show(request)
         }
 
-        "return HTML" in {
-          mockIndividualAuthorised()
-          contentType(result) shouldBe Some("text/html")
-          charset(result) shouldBe Some("utf-8")
+        "return 303" in {
+          status(result) shouldBe Status.SEE_OTHER
         }
 
-        "remove the email session key from the session" in {
-          session(result).get(prepopulationEmailKey) shouldBe None
-        }
-
-        "remove the validation email session key from the session" in {
-          session(result).get(validationEmailKey) shouldBe None
-        }
-
-        "render the email change success page" in {
-          mockIndividualAuthorised()
-          messages(document.select("#content article p:nth-of-type(1)").text()) shouldBe
-            "We will send you an update within 15 working days."
-        }
-      }
-
-      "the contact preference feature switch is disabled" should {
-
-        lazy val result = TestController.show(request.withSession(
-          prepopulationEmailKey -> "myemail@gmail.com",
-          validationEmailKey -> "anotheremail@gmail.com"
-        ))
-        lazy val document = Jsoup.parse(bodyOf(result))
-
-        "return 200" in {
-          mockIndividualAuthorised()
-          mockConfig.features.contactPreferencesEnabled(false)
-          status(result) shouldBe Status.OK
-        }
-        "return HTML" in {
-          mockIndividualAuthorised()
-          contentType(result) shouldBe Some("text/html")
-          charset(result) shouldBe Some("utf-8")
-        }
-
-        "remove the email session key from the session" in {
-          session(result).get(prepopulationEmailKey) shouldBe None
-        }
-
-        "remove the validation email session key from the session" in {
-          session(result).get(validationEmailKey) shouldBe None
-        }
-
-        "render the email change success page" in {
-          mockIndividualAuthorised()
-          messages(document.select("#content article p:nth-of-type(1)").text()) shouldBe
-            "We will send an email within 2 working days telling you whether or not the request has been accepted. " +
-            "You can also go to your messages in your business tax account."
+        "redirect to the capture email page" in {
+          redirectLocation(result) shouldBe Some(controllers.email.routes.CaptureEmailController.show().url)
         }
       }
     }
 
-
     "a user is does not have a valid enrolment" should {
 
-      lazy val result = TestController.show(request)
+      lazy val result = {
+        mockIndividualWithoutEnrolment()
+        TestController.show(request)
+      }
 
       "return 403" in {
-        mockIndividualWithoutEnrolment()
         status(result) shouldBe Status.FORBIDDEN
       }
 

--- a/test/mocks/MockAuditingService.scala
+++ b/test/mocks/MockAuditingService.scala
@@ -26,18 +26,14 @@ import utils.TestUtil
 
 import scala.concurrent.ExecutionContext
 
-trait MockAuditingService extends TestUtil with MockitoSugar {
-
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    reset(mockAuditingService)
-  }
+trait MockAuditingService extends MockitoSugar {
 
   val mockAuditingService: AuditingService = mock[AuditingService]
 
-  def verifyExtendedAudit(model: ExtendedAuditModel, path: Option[String] = None): Unit =
+  def verifyExtendedAudit(model: ExtendedAuditModel): Unit =
     verify(mockAuditingService).extendedAudit(
-      ArgumentMatchers.eq(model)
+      ArgumentMatchers.eq(model),
+      ArgumentMatchers.any[String]
     )(
       ArgumentMatchers.any[HeaderCarrier],
       ArgumentMatchers.any[ExecutionContext]

--- a/test/utils/TestUtil.scala
+++ b/test/utils/TestUtil.scala
@@ -37,7 +37,6 @@ trait TestUtil extends UnitSpec with GuiceOneAppPerSuite with MaterializerSuppor
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    mockConfig.features.contactPreferencesEnabled(false)
     mockConfig.features.languageSelectorEnabled(true)
     mockConfig.features.changeContactDetailsEnabled(true)
     mockConfig.features.agentAccessEnabled(true)

--- a/test/views/email/EmailChangeSuccessViewSpec.scala
+++ b/test/views/email/EmailChangeSuccessViewSpec.scala
@@ -37,88 +37,68 @@ class EmailChangeSuccessViewSpec extends ViewBaseSpec {
 
   "The Email Change Successful view" when {
 
-    "the contact preference feature switch is enabled" when {
+    "the contact preference is successfully retrieved" when {
 
-      "the contact preference is successfully retrieved" when {
+      "the contact preference is Digital" should {
 
-        "the contact preference is Digital" should {
+        lazy val view = injectedView(Some(ContactPreference.digital))(request, messages, mockConfig)
 
-          lazy val view = injectedView(Some(ContactPreference.digital))(request, messages, mockConfig)
+        lazy implicit val document: Document = Jsoup.parse(view.body)
 
-          lazy implicit val document: Document = Jsoup.parse(view.body)
-
-          "have the correct page title" in {
-            mockConfig.features.contactPreferencesEnabled(true)
-
-            elementText(Selectors.title) shouldBe "We have received the new email address"
-          }
-
-          "have the correct heading" in {
-            elementText(Selectors.pageHeading) shouldBe "We have received the new email address"
-          }
-
-          "have a GA tag for the page view" in {
-            element(Selectors.pageHeading).select("h1").attr("data-journey") shouldBe "email-address:view:change-email-success"
-          }
-
-          "have a finish button with the correct text" in {
-            elementText(Selectors.button) shouldBe "Finish"
-          }
-
-          "have a finish button which navigates to the Change of Circs overview page" in {
-            element(Selectors.button).select("a").attr("href") shouldBe "mockManageVatOverviewUrl"
-          }
-
-          "have the correct first paragraph" in {
-            elementText(Selectors.paragraphOne) shouldBe "We will send you an email within 2 working days with an update," +
-              " followed by a letter to your principal place of business." +
-              " You can also go to your HMRC secure messages to find out if your request has been accepted."
-          }
-
-          "have the correct second paragraph" in {
-            elementText(Selectors.paragraphTwo) shouldBe "Ensure your contact details are up to date."
-          }
-
-          "have a GA tag for the clicking finish button" in {
-            element(Selectors.button).select("h1").attr("data-journey") contains "email-address:confirm:finish-email-change"
-          }
-
+        "have the correct page title" in {
+          elementText(Selectors.title) shouldBe "We have received the new email address"
         }
 
-        "the contact preference is Paper" should {
-
-          lazy val view = injectedView(Some(ContactPreference.paper))
-          lazy implicit val document: Document = Jsoup.parse(view.body)
-
-          "have the correct first paragraph" in {
-            mockConfig.features.contactPreferencesEnabled(true)
-            elementText(Selectors.paragraphOne) shouldBe "We will send a letter to your principal place of" +
-              " business with an update within 15 working days."
-          }
+        "have the correct heading" in {
+          elementText(Selectors.pageHeading) shouldBe "We have received the new email address"
         }
-      }
 
-      "the contact preference is not retrieved" should {
+        "have a GA tag for the page view" in {
+          element(Selectors.pageHeading).select("h1").attr("data-journey") shouldBe "email-address:view:change-email-success"
+        }
 
-        lazy implicit val document: Document = Jsoup.parse(injectedView().body)
+        "have a finish button with the correct text" in {
+          elementText(Selectors.button) shouldBe "Finish"
+        }
+
+        "have a finish button which navigates to the Change of Circs overview page" in {
+          element(Selectors.button).select("a").attr("href") shouldBe "mockManageVatOverviewUrl"
+        }
 
         "have the correct first paragraph" in {
-          mockConfig.features.contactPreferencesEnabled(true)
-          elementText(Selectors.paragraphOne) shouldBe "We will send you an update within 15 working days."
+          elementText(Selectors.paragraphOne) shouldBe "We will send you an email within 2 working days with an update," +
+            " followed by a letter to your principal place of business." +
+            " You can also go to your HMRC secure messages to find out if your request has been accepted."
+        }
+
+        "have the correct second paragraph" in {
+          elementText(Selectors.paragraphTwo) shouldBe "Ensure your contact details are up to date."
+        }
+
+        "have a GA tag for the clicking finish button" in {
+          element(Selectors.button).select("h1").attr("data-journey") contains "email-address:confirm:finish-email-change"
+        }
+
+      }
+
+      "the contact preference is Paper" should {
+
+        lazy val view = injectedView(Some(ContactPreference.paper))
+        lazy implicit val document: Document = Jsoup.parse(view.body)
+
+        "have the correct first paragraph" in {
+          elementText(Selectors.paragraphOne) shouldBe "We will send a letter to your principal place of" +
+            " business with an update within 15 working days."
         }
       }
     }
 
-    "the contact preference feature switch is not enabled" should {
+    "the contact preference is not retrieved" should {
 
       lazy implicit val document: Document = Jsoup.parse(injectedView().body)
 
       "have the correct first paragraph" in {
-        mockConfig.features.contactPreferencesEnabled(false)
-
-        elementText(Selectors.paragraphOne) shouldBe "We will send an email within 2 working days " +
-          "telling you whether or not the request has been accepted. " +
-          "You can also go to your messages in your business tax account."
+        elementText(Selectors.paragraphOne) shouldBe "We will send you an update within 15 working days."
       }
     }
   }


### PR DESCRIPTION
In order to keep the implementation tidy, as part of this PR I have also removed the usages of the `contactPreferencesEnabled` feature switch. This has been switched on in all environments for a while now.