### PR TITLE
BTAT-6934 Made use of entity name session key for confirmation page

### DIFF
--- a/app/common/SessionKeys.scala
+++ b/app/common/SessionKeys.scala
@@ -20,6 +20,7 @@ object SessionKeys {
   val clientVrn: String = "CLIENT_VRN"
   val inFlightContactDetailsChangeKey: String = "inFlightContactDetailsChange"
   val verifiedAgentEmail: String = "verifiedAgentEmail"
+  val mtdVatAgentClientName: String = "mtdVatAgentClientName"
 
   val validationEmailKey: String = "vatCorrespondenceValidationEmail"
   val prepopulationEmailKey: String = "vatCorrespondencePrepopulationEmail"


### PR DESCRIPTION
There were no issues I could see with the wiring up but I noticed that we already had the client's business name in session for the agent journey. It looks like this was recently added to the Agent Action page. I've added it here as a nice-to-have to prevent extra customer info calls when the session value is available.