### PR TITLE
BTAT-7025 Implemented remove landline journey

### DIFF
--- a/app/controllers/landlineNumber/CaptureLandlineNumberController.scala
+++ b/app/controllers/landlineNumber/CaptureLandlineNumberController.scala
@@ -66,7 +66,7 @@ class CaptureLandlineNumberController @Inject()(val vatSubscriptionService: VatS
       } yield {
         validationLandlineResult match {
           case Some(landline) =>
-            Ok(captureLandlineNumberView(landlineNumberForm(landline).fill(prepopLandlineResult)))
+            Ok(captureLandlineNumberView(landlineNumberForm(landline).fill(prepopLandlineResult), landline))
               .addingToSession(SessionKeys.validationLandlineKey -> landline)
           case _ => errorHandler.showInternalServerError
         }
@@ -83,7 +83,7 @@ class CaptureLandlineNumberController @Inject()(val vatSubscriptionService: VatS
       case Some(landline) =>
         landlineNumberForm(landline).bindFromRequest.fold(
           errorForm => {
-            BadRequest(captureLandlineNumberView(errorForm))
+            BadRequest(captureLandlineNumberView(errorForm, landline))
           },
 
           formValue => {

--- a/app/controllers/landlineNumber/ConfirmLandlineNumberController.scala
+++ b/app/controllers/landlineNumber/ConfirmLandlineNumberController.scala
@@ -46,11 +46,7 @@ class ConfirmLandlineNumberController @Inject()(val errorHandler: ErrorHandler,
 
   implicit val ec: ExecutionContext = mcc.executionContext
 
-<<<<<<< HEAD
   def show: Action[AnyContent] = (allowAgentPredicate andThen inFlightLandlineNumberPredicate) { implicit user =>
-=======
-  def show: Action[AnyContent] = (allowAgentPredicate andThen inFlightLandlinePredicate) { implicit user =>
->>>>>>> Renamed predicate/messages to be landline specific
     val prepopulationLandline = user.session.get(prepopulationLandlineKey).filter(_.nonEmpty)
     val validationLandline = user.session.get(validationLandlineKey).filter(_.nonEmpty)
 
@@ -70,11 +66,7 @@ class ConfirmLandlineNumberController @Inject()(val errorHandler: ErrorHandler,
     }
   }
 
-<<<<<<< HEAD
   def updateLandlineNumber: Action[AnyContent] = (allowAgentPredicate andThen inFlightLandlineNumberPredicate).async {
-=======
-  def updateLandlineNumber: Action[AnyContent] = (allowAgentPredicate andThen inFlightLandlinePredicate).async {
->>>>>>> Renamed predicate/messages to be landline specific
     implicit user =>
       val enteredLandline = user.session.get(SessionKeys.prepopulationLandlineKey)
       val existingLandline = user.session.get(validationLandlineKey).filter(_.nonEmpty)

--- a/app/controllers/landlineNumber/ConfirmLandlineNumberController.scala
+++ b/app/controllers/landlineNumber/ConfirmLandlineNumberController.scala
@@ -46,7 +46,11 @@ class ConfirmLandlineNumberController @Inject()(val errorHandler: ErrorHandler,
 
   implicit val ec: ExecutionContext = mcc.executionContext
 
+<<<<<<< HEAD
   def show: Action[AnyContent] = (allowAgentPredicate andThen inFlightLandlineNumberPredicate) { implicit user =>
+=======
+  def show: Action[AnyContent] = (allowAgentPredicate andThen inFlightLandlinePredicate) { implicit user =>
+>>>>>>> Renamed predicate/messages to be landline specific
     val prepopulationLandline = user.session.get(prepopulationLandlineKey).filter(_.nonEmpty)
     val validationLandline = user.session.get(validationLandlineKey).filter(_.nonEmpty)
 
@@ -66,7 +70,11 @@ class ConfirmLandlineNumberController @Inject()(val errorHandler: ErrorHandler,
     }
   }
 
+<<<<<<< HEAD
   def updateLandlineNumber: Action[AnyContent] = (allowAgentPredicate andThen inFlightLandlineNumberPredicate).async {
+=======
+  def updateLandlineNumber: Action[AnyContent] = (allowAgentPredicate andThen inFlightLandlinePredicate).async {
+>>>>>>> Renamed predicate/messages to be landline specific
     implicit user =>
       val enteredLandline = user.session.get(SessionKeys.prepopulationLandlineKey)
       val existingLandline = user.session.get(validationLandlineKey).filter(_.nonEmpty)

--- a/app/controllers/landlineNumber/ConfirmRemoveLandlineController.scala
+++ b/app/controllers/landlineNumber/ConfirmRemoveLandlineController.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.landlineNumber
+
+import common.SessionKeys.{validationLandlineKey, prepopulationLandlineKey}
+import config.AppConfig
+import controllers.BaseController
+import controllers.predicates.AuthPredicateComponents
+import controllers.predicates.inflight.InFlightPredicateComponents
+import javax.inject.Inject
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import views.html.landlineNumber.ConfirmRemoveLandlineView
+
+import scala.concurrent.Future
+
+class ConfirmRemoveLandlineController @Inject()(val confirmRemoveLandline: ConfirmRemoveLandlineView)
+                                               (implicit appConfig: AppConfig,
+                                                mcc: MessagesControllerComponents,
+                                                authComps: AuthPredicateComponents,
+                                                inFlightComps: InFlightPredicateComponents) extends BaseController {
+
+  def show(): Action[AnyContent] = (allowAgentPredicate andThen inFlightLandlineNumberPredicate).async { implicit user =>
+    user.session.get(validationLandlineKey) match {
+      case Some(landline) =>
+        Future.successful(Ok(confirmRemoveLandline(landline)))
+      case None =>
+        Future.successful(Redirect(routes.CaptureLandlineNumberController.show()))
+    }
+  }
+
+  def removeLandlineNumber(): Action[AnyContent] = (allowAgentPredicate andThen inFlightLandlineNumberPredicate).async { implicit user =>
+    user.session.get(validationLandlineKey) match {
+      case Some(_) =>
+        Future.successful(Redirect(routes.ConfirmLandlineNumberController.updateLandlineNumber())
+            .addingToSession(prepopulationLandlineKey -> ""))
+      case None =>
+        Future.successful(Redirect(routes.CaptureLandlineNumberController.show()))
+    }
+  }
+}

--- a/app/controllers/website/CaptureWebsiteController.scala
+++ b/app/controllers/website/CaptureWebsiteController.scala
@@ -66,7 +66,7 @@ class CaptureWebsiteController @Inject()(val vatSubscriptionService: VatSubscrip
       } yield {
         validation match {
           case Some(valWebsite) =>
-            Ok(captureWebsiteView(websiteForm(valWebsite).fill(prepopulation), websiteNotChangedError = false, valWebsite))
+            Ok(captureWebsiteView(websiteForm(valWebsite).fill(prepopulation), valWebsite))
               .addingToSession(SessionKeys.validationWebsiteKey -> valWebsite)
           case _ => errorHandler.showInternalServerError
         }
@@ -82,9 +82,7 @@ class CaptureWebsiteController @Inject()(val vatSubscriptionService: VatSubscrip
     validationWebsite match {
       case Some(validation) => websiteForm(validation).bindFromRequest.fold(
         errorForm => {
-          val notChanged: Boolean = errorForm.errors.head.message == user.messages.apply("captureWebsite.error.notChanged")
-          Future.successful(BadRequest(captureWebsiteView(errorForm, notChanged, validation)))
-
+          Future.successful(BadRequest(captureWebsiteView(errorForm, validation)))
         },
         website     => {
           Future.successful(Redirect(routes.ConfirmWebsiteController.show())

--- a/app/views/landlineNumber/CaptureLandlineNumberView.scala.html
+++ b/app/views/landlineNumber/CaptureLandlineNumberView.scala.html
@@ -19,33 +19,35 @@
 
 @this(mainTemplate: MainTemplate, form: FormWithCSRF, errorSummary: ErrorSummary, input: Input)
 
-@(contactNumbersForm: Form[String])(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(landlineForm: Form[String], currentLandline: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @mainTemplate(
-  if(contactNumbersForm.errors.nonEmpty) messages("common.error.prefixTitle", messages("captureLandline.title"))
+  if(landlineForm.errors.nonEmpty) messages("common.error.prefixTitle", messages("captureLandline.title"))
   else messages("captureLandline.title")
 ) {
 
   <a class="link-back" href="@appConfig.manageVatSubscriptionServicePath">@messages("base.back")</a>
 
-  @errorSummary(messages("common.error.heading"), contactNumbersForm, forceDivToAppear = false)
+  @errorSummary(messages("common.error.heading"), landlineForm, forceDivToAppear = false)
 
   <h1 class="heading-large">@messages("captureLandline.title")</h1>
 
   @form(action = controllers.landlineNumber.routes.CaptureLandlineNumberController.submit) {
-    <fieldset>
+    <div class ="form-group">
+      @input(
+        landlineForm("landlineNumber"),
+        '_label -> messages("captureLandline.title"),
+        '_inputClass -> "form-control form-control--block",
+        '_inputHint -> messages("captureLandline.hint"),
+        '_labelTextClass -> "visuallyhidden"
+      )
+    </div>
 
-        <div class ="form-group">
-          @input(
-            contactNumbersForm("landlineNumber"),
-            '_label -> messages("captureLandline.title"),
-            '_inputClass -> "form-control form-control--block",
-            '_inputHint -> messages("captureLandline.hint"),
-            '_labelTextClass -> "visuallyhidden"
-          )
-        </div>
-
-    </fieldset>
+    @if(currentLandline != "") {
+      <p><a id="remove-landline" href='@controllers.landlineNumber.routes.ConfirmRemoveLandlineController.show().url'>
+        @messages("captureLandline.remove")
+      </a></p>
+    }
 
     <div class="form-group">
       <button class="button" type="submit">@messages("common.continue")</button>

--- a/app/views/landlineNumber/ConfirmLandlineNumberView.scala.html
+++ b/app/views/landlineNumber/ConfirmLandlineNumberView.scala.html
@@ -21,21 +21,21 @@
 
 @(landline: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
-@mainTemplate(title = messages("confirmPhoneNumbers.title")) {
+@mainTemplate(title = messages("confirmLandlineNumber.title")) {
 
 <a class="link-back" href="@controllers.landlineNumber.routes.CaptureLandlineNumberController.show()">
   @messages("base.back")
 </a>
 
-<h1 class="heading-large">@messages("confirmPhoneNumbers.heading")</h1>
+<h1 class="heading-large">@messages("confirmLandlineNumber.title")</h1>
 
 <p>
-@messages("confirmPhoneNumbers.landline") @landline
+@messages("confirmLandlineNumber.landline") @landline
 </p>
 
 <p>
   <a href="@controllers.landlineNumber.routes.CaptureLandlineNumberController.show()">
-    @messages("confirmPhoneNumbers.edit")
+    @messages("confirmLandlineNumber.edit")
   </a>
 </p>
 

--- a/app/views/landlineNumber/ConfirmRemoveLandlineView.scala.html
+++ b/app/views/landlineNumber/ConfirmRemoveLandlineView.scala.html
@@ -1,0 +1,35 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.AppConfig
+
+@this(mainTemplate: MainTemplate)
+
+@(landline: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@mainTemplate(title = messages("confirmRemoveLandline.title")) {
+
+<a class="link-back" href='@controllers.landlineNumber.routes.CaptureLandlineNumberController.show()'>@messages("base.back")</a>
+
+<h1 class="heading-large">@messages("confirmRemoveLandline.heading", landline)</h1>
+
+<p>
+  <a href="@appConfig.manageVatSubscriptionServicePath">@messages("common.cancel")</a>
+</p>
+
+<a href='@controllers.landlineNumber.routes.ConfirmRemoveLandlineController.removeLandlineNumber().url'
+   role="button" tabindex="0" class="button">@messages("base.confirmAndContinue")</a>
+}

--- a/app/views/website/CaptureWebsiteView.scala.html
+++ b/app/views/website/CaptureWebsiteView.scala.html
@@ -20,7 +20,7 @@
 
 @this(mainTemplate: MainTemplate, form: FormWithCSRF, errorSummary: ErrorSummary, input: Input)
 
-@(websiteForm: Form[String], websiteNotChangedError: Boolean, currentWebsite: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(websiteForm: Form[String], currentWebsite: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
     @mainTemplate(if(websiteForm.errors.nonEmpty) messages("common.error.prefixTitle", messages("captureWebsite.title")) else messages("captureWebsite.title")) {
 
@@ -45,13 +45,14 @@
             )
             </div>
 
+            @if(currentWebsite != ""){
+              <p><a id="remove-website" href='@controllers.website.routes.ConfirmRemoveWebsiteController.show().url'>
+                @messages("captureWebsite.removeWebsite.linkText")
+              </a></p>
+            }
+
             <div class="form-group">
                 <button class="button" type="submit">@messages("common.continue")</button>
             </div>
-        }
-        @if(currentWebsite != ""){
-            <p><a id="remove-website" href='@controllers.website.routes.ConfirmRemoveWebsiteController.show().url'>
-              @messages("captureWebsite.removeWebsite.linkText")
-            </a></p>
         }
     }

--- a/app/views/website/ConfirmRemoveWebsiteView.scala.html
+++ b/app/views/website/ConfirmRemoveWebsiteView.scala.html
@@ -27,7 +27,7 @@
  <h1 class="heading-large">@messages("confirmWebsiteRemove.heading",website)</h1>
 
  <p>
-   <a href= "@appConfig.manageVatSubscriptionServicePath">@messages("confirmWebsiteRemove.cancel")</a>
+   <a href="@appConfig.manageVatSubscriptionServicePath">@messages("common.cancel")</a>
  </p>
 
  <a href='@controllers.website.routes.ConfirmRemoveWebsiteController.removeWebsiteAddress().url'

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -45,6 +45,10 @@ POST        /new-landline-number                   controllers.landlineNumber.Ca
 GET         /confirm-new-landline-number           controllers.landlineNumber.ConfirmLandlineNumberController.show
 GET         /update-new-landline-number            controllers.landlineNumber.ConfirmLandlineNumberController.updateLandlineNumber
 
+# remove landline number
+GET         /confirm-remove-landline-number        controllers.landlineNumber.ConfirmRemoveLandlineController.show
+GET         /update-remove-landline-number         controllers.landlineNumber.ConfirmRemoveLandlineController.removeLandlineNumber
+
 # landline number change successful
 GET         /landline-number-confirmation          controllers.ChangeSuccessController.landlineNumber
 

--- a/conf/messages
+++ b/conf/messages
@@ -72,6 +72,7 @@ captureLandline.title = What is the landline number?
 captureLandline.hint = You will need to include the country code for international telephone numbers, for example ''+44''.
 captureLandline.error.notChanged = You have not made any changes to the landline number
 captureLandline.error.invalid = Enter a landline number in the correct format, like 01632 960000 or 020 7946 0000
+captureLandline.remove = Remove landline number
 
 captureMobile.title = What is the mobile number?
 captureMobile.hint = You will need to include the country code for international telephone numbers, for example ''+44''.
@@ -143,3 +144,6 @@ confirmMobile.heading = Confirm the mobile number
 confirmLandlineNumber.title = Confirm the landline number
 confirmLandlineNumber.landline = The new landline number is
 confirmLandlineNumber.edit = Change the landline number
+
+confirmRemoveLandline.title = Confirm you want to remove the landline number
+confirmRemoveLandline.heading = Confirm you want to remove the landline number: {0}

--- a/conf/messages
+++ b/conf/messages
@@ -21,6 +21,7 @@ common.changeClient = Change client
 common.agent.updateClient1 = We’ll also contact
 common.agent.updateClient2 = with an update.
 common.agent.yourClient = your client
+common.cancel = Cancel
 
 standardError.title = There is a problem with the service
 standardError.heading = Sorry, there is a problem with the service
@@ -94,7 +95,6 @@ confirmWebsite.change = Change the website address
 
 confirmWebsiteRemove.title = Confirm you want to remove the website address
 confirmWebsiteRemove.heading = Confirm you want to remove the website address: {0}
-confirmWebsiteRemove.cancel = Cancel
 
 verifyEmail.title = Verify your email address
 verifyEmail.heading = Verify your email address
@@ -135,11 +135,11 @@ inFlightChange.emailAddress = email address
 
 confirmPhoneNumbers.notProvided = Not provided
 confirmPhoneNumbers.numberRemoved = Number removed
-confirmPhoneNumbers.title = Confirm the landline number
-confirmPhoneNumbers.heading = Confirm the landline number
-confirmPhoneNumbers.landline = The new landline number is
-confirmPhoneNumbers.mobile = Mobile
-confirmPhoneNumbers.edit = Change the landline number
+
 confirmMobile.edit = Change the mobile number
 confirmMobile.newNumber = The new mobile number is
 confirmMobile.heading = Confirm the mobile number
+
+confirmLandlineNumber.title = Confirm the landline number
+confirmLandlineNumber.landline = The new landline number is
+confirmLandlineNumber.edit = Change the landline number

--- a/it/pages/landlineNumber/ConfirmLandlineNumberPageSpec.scala
+++ b/it/pages/landlineNumber/ConfirmLandlineNumberPageSpec.scala
@@ -45,7 +45,7 @@ class ConfirmLandlineNumberPageSpec extends BasePageISpec {
 
           result should have(
             httpStatus(Status.OK),
-            pageTitle(generateDocumentTitle("confirmPhoneNumbers.title"))
+            pageTitle(generateDocumentTitle("confirmLandlineNumber.title"))
           )
         }
       }

--- a/it/pages/landlineNumber/ConfirmRemoveLandlinePageSpec.scala
+++ b/it/pages/landlineNumber/ConfirmRemoveLandlinePageSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.landlineNumber
+
+import common.SessionKeys.validationLandlineKey
+import pages.BasePageISpec
+import play.api.http.Status
+import play.api.libs.ws.WSResponse
+
+class ConfirmRemoveLandlinePageSpec extends BasePageISpec {
+
+  val path = "/confirm-remove-landline-number"
+  val testValidationLandline: String = "01952123456"
+
+  "Calling the Confirm Remove Landline route" should {
+
+    def show: WSResponse =
+      get(path, Map(validationLandlineKey -> testValidationLandline) ++ formatInflightChange(Some("false")))
+
+    "load successfully" in {
+
+      given.user.isAuthenticated
+      val result = show
+      result should have(
+        httpStatus(Status.OK),
+        pageTitle(generateDocumentTitle("confirmRemoveLandline.title"))
+      )
+    }
+  }
+}

--- a/test/controllers/landlineNumber/ConfirmRemoveLandlineControllerSpec.scala
+++ b/test/controllers/landlineNumber/ConfirmRemoveLandlineControllerSpec.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.landlineNumber
+
+import assets.BaseTestConstants.testValidationLandline
+import common.SessionKeys.{validationLandlineKey, prepopulationLandlineKey}
+import controllers.ControllerBaseSpec
+import play.api.http.Status
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.landlineNumber.ConfirmRemoveLandlineView
+
+class ConfirmRemoveLandlineControllerSpec extends ControllerBaseSpec {
+
+  val controller = new ConfirmRemoveLandlineController(inject[ConfirmRemoveLandlineView])
+  val requestWithLandline: FakeRequest[AnyContentAsEmpty.type] =
+    request.withSession(validationLandlineKey -> testValidationLandline)
+
+  "Calling the show() action in ConfirmRemoveLandlineController" when {
+
+    "there is a validation landline number in session" should {
+
+      "return 200" in {
+        val result = controller.show()(requestWithLandline)
+        status(result) shouldBe Status.OK
+      }
+    }
+
+    "there isn't a validation landline number in session" should {
+
+      lazy val result = controller.show()(request)
+
+      "return 303" in {
+        status(result) shouldBe Status.SEE_OTHER
+      }
+
+      "redirect to the capture landline page" in {
+        redirectLocation(result) shouldBe Some(routes.CaptureLandlineNumberController.show().url)
+      }
+    }
+
+    "the user is not authorised" should {
+
+      "return 403" in {
+        val result = {
+          mockIndividualWithoutEnrolment()
+          controller.show()(request)
+        }
+
+        status(result) shouldBe Status.FORBIDDEN
+      }
+    }
+  }
+
+  "Calling the removeLandlineNumber() action in ConfirmRemoveLandlineController" when {
+
+    "there is a validation landline number in session" should {
+
+      lazy val result = controller.removeLandlineNumber()(requestWithLandline)
+
+      "return 303" in {
+        status(result) shouldBe Status.SEE_OTHER
+      }
+
+      "redirect to the updateLandlineNumber() action in ConfirmLandlineNumberController" in {
+        redirectLocation(result) shouldBe Some(routes.ConfirmLandlineNumberController.updateLandlineNumber().url)
+      }
+
+      "add a blank prepopulation landline to the session" in {
+        session(result).get(prepopulationLandlineKey) shouldBe Some("")
+      }
+    }
+
+    "there isn't a validation landline number in session" should {
+
+      lazy val result = controller.removeLandlineNumber()(request)
+
+      "return 303" in {
+        status(result) shouldBe Status.SEE_OTHER
+      }
+
+      "redirect to the capture landline page" in {
+        redirectLocation(result) shouldBe Some(routes.CaptureLandlineNumberController.show().url)
+      }
+    }
+
+    "the user is not authorised" should {
+
+      "return 403" in {
+        val result = {
+          mockIndividualWithoutEnrolment()
+          controller.removeLandlineNumber()(request)
+        }
+
+        status(result) shouldBe Status.FORBIDDEN
+      }
+    }
+  }
+}

--- a/test/controllers/website/ConfirmRemoveWebsiteControllerSpec.scala
+++ b/test/controllers/website/ConfirmRemoveWebsiteControllerSpec.scala
@@ -49,9 +49,9 @@ class ConfirmRemoveWebsiteControllerSpec extends ControllerBaseSpec  {
     }
   }
 
-  "Calling the show action in ConfirmWebsiteController" when {
+  "Calling the show action in ConfirmRemoveWebsiteController" when {
 
-    "there is an website address in session" should {
+    "there is a website address in session" should {
 
       "return 200" in {
         val result = controller.show(requestWithValidationWebsiteKey)
@@ -85,7 +85,7 @@ class ConfirmRemoveWebsiteControllerSpec extends ControllerBaseSpec  {
     }
   }
 
-  "Calling the removeWebsiteAddress() action in ConfirmWebsiteController" when {
+  "Calling the removeWebsiteAddress() action in ConfirmRemoveWebsiteController" when {
 
     "there is a validation website address in session" should {
 

--- a/test/views/landlineNumber/CaptureLandlineNumberViewSpec.scala
+++ b/test/views/landlineNumber/CaptureLandlineNumberViewSpec.scala
@@ -34,9 +34,9 @@ class CaptureLandlineNumberViewSpec extends ViewBaseSpec {
 
       "there are no errors in the form" should {
 
-        val view = injectedView(landlineNumberForm(testValidationLandline))(user, messages, mockConfig)
+        val view = injectedView(landlineNumberForm(testValidationLandline), testValidationLandline)(user, messages, mockConfig)
         implicit val document: Document = Jsoup.parse(view.body)
-        val fieldLabel: String = "#content > article > form > fieldset > div > label "
+        val fieldLabel: String = "#content > article > form > div > label "
 
         "have the correct title" in {
           document.title shouldBe "What is the landline number? - Business tax account - GOV.UK"
@@ -55,6 +55,17 @@ class CaptureLandlineNumberViewSpec extends ViewBaseSpec {
           elementText(s"$fieldLabel > span.visuallyhidden") shouldBe "What is the landline number?"
         }
 
+        "have a link to remove the landline" which {
+
+          "has the correct text" in {
+            elementText("#remove-landline") shouldBe "Remove landline number"
+          }
+
+          "has the correct link location" in {
+            element("#remove-landline").attr("href") shouldBe routes.ConfirmRemoveLandlineController.show().url
+          }
+        }
+
         "have a button" which {
 
           "has the correct text" in {
@@ -68,8 +79,9 @@ class CaptureLandlineNumberViewSpec extends ViewBaseSpec {
       }
 
       "there are errors in the form" should {
-        val view = injectedView(landlineNumberForm(testValidationLandline)
-          .withError("landlineNumber", messages("captureLandline.error.notChanged")))(user, messages, mockConfig)
+        val view = injectedView(landlineNumberForm(testValidationLandline).bind(
+          Map("landlineNumber" -> testValidationLandline)
+        ), testValidationLandline)(user, messages, mockConfig)
         implicit val document: Document = Jsoup.parse(view.body)
 
         "have the correct document title" in {
@@ -96,7 +108,7 @@ class CaptureLandlineNumberViewSpec extends ViewBaseSpec {
     "the user is an agent" when {
 
       "there are no errors in the form" should {
-        val view = injectedView(landlineNumberForm(testValidationLandline))(agent, messages, mockConfig)
+        val view = injectedView(landlineNumberForm(testValidationLandline), testValidationLandline)(agent, messages, mockConfig)
         implicit val document: Document = Jsoup.parse(view.body)
 
         "have the correct title" in {

--- a/test/views/landlineNumber/ConfirmRemoveLandlineViewSpec.scala
+++ b/test/views/landlineNumber/ConfirmRemoveLandlineViewSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.landlineNumber
+
+import assets.BaseTestConstants.testValidationLandline
+import controllers.landlineNumber.routes
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import views.ViewBaseSpec
+import views.html.landlineNumber.ConfirmRemoveLandlineView
+
+class ConfirmRemoveLandlineViewSpec extends ViewBaseSpec {
+
+  val injectedView: ConfirmRemoveLandlineView = inject[ConfirmRemoveLandlineView]
+
+  "The ConfirmRemoveLandline page" when {
+
+    "the user is a principal entity" should {
+
+      lazy val view = injectedView(testValidationLandline)(user, messages, mockConfig)
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "have the correct title" in {
+        document.title shouldBe
+          s"Confirm you want to remove the landline number - Business tax account - GOV.UK"
+      }
+
+      "have the correct heading" in {
+        elementText("h1") shouldBe s"Confirm you want to remove the landline number: $testValidationLandline"
+      }
+
+      "have a cancel link" which {
+
+        "has the correct text" in {
+          elementText("#content > article > p > a") shouldBe "Cancel"
+        }
+
+        "has the correct link location" in {
+          element("#content > article > p > a").attr("href") shouldBe mockConfig.manageVatSubscriptionServicePath
+        }
+      }
+
+      "have a continue button" which {
+
+        "has the correct text" in {
+          elementText(".button") shouldBe "Confirm and continue"
+        }
+
+        "has the correct link location" in {
+          element(".button").attr("href") shouldBe routes.ConfirmRemoveLandlineController.removeLandlineNumber().url
+        }
+      }
+    }
+
+    "the user is an agent" should {
+
+      lazy val view = injectedView(testValidationLandline)(agent, messages, mockConfig)
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "have the correct title" in {
+        document.title shouldBe
+          s"Confirm you want to remove the landline number - Your client’s VAT details - GOV.UK"
+      }
+    }
+  }
+}

--- a/test/views/website/CaptureWebsiteViewSpec.scala
+++ b/test/views/website/CaptureWebsiteViewSpec.scala
@@ -47,7 +47,7 @@ class CaptureWebsiteViewSpec extends ViewBaseSpec {
 
         "the user already has a website in ETMP" should {
           lazy val view: Html =
-            injectedView(websiteForm(testWebsite).fill(testWebsite), websiteNotChangedError = false, testWebsite)(user, messages, mockConfig)
+            injectedView(websiteForm(testWebsite).fill(testWebsite), testWebsite)(user, messages, mockConfig)
 
           lazy implicit val document: Document = Jsoup.parse(view.body)
 
@@ -98,7 +98,7 @@ class CaptureWebsiteViewSpec extends ViewBaseSpec {
         }
 
         "the user has no website in ETMP" should {
-          lazy val view: Html = injectedView(websiteForm(testWebsite), websiteNotChangedError = false, "")
+          lazy val view: Html = injectedView(websiteForm(testWebsite), "")
           lazy implicit val document: Document = Jsoup.parse(view.body)
 
           "have the website text field with no pre-populated value" in {
@@ -114,7 +114,7 @@ class CaptureWebsiteViewSpec extends ViewBaseSpec {
     "the user is an agent" should {
 
       "there are no errors in the form" should {
-        val view = injectedView(websiteForm(testWebsite).fill(testWebsite), websiteNotChangedError = false, testWebsite)(agent, messages, mockConfig)
+        val view = injectedView(websiteForm(testWebsite).fill(testWebsite), testWebsite)(agent, messages, mockConfig)
         implicit val document: Document = Jsoup.parse(view.body)
 
         "have the correct title" in {


### PR DESCRIPTION
The first commit is a bit of cleanup work to reword a few remaining "contactNumbers" values to be landline specific. The second commit removes a pointless boolean value from the Capture Website view and fixes a bug where the "Remove" link was incorrectly below the button.