### PR TITLE
[BTAT-8081] Wire up contact pref paper -> digital and add email journey

### DIFF
--- a/app/common/SessionKeys.scala
+++ b/app/common/SessionKeys.scala
@@ -28,7 +28,6 @@ object SessionKeys {
   val emailChangeSuccessful: String = "vatCorrespondenceEmailChangeSuccessful"
 
   val contactPrefUpdate: String = "vatCorrespondenceEmailPrefUpdate"
-  val contactPrefConfirmed: String = "vatCorrespondenceEmailPrefConfirmed"
 
   val validationWebsiteKey: String = "vatCorrespondenceValidationWebsite"
   val prepopulationWebsiteKey: String = "vatCorrespondencePrepopulationWebsite"

--- a/app/controllers/contactPreference/EmailPreferenceController.scala
+++ b/app/controllers/contactPreference/EmailPreferenceController.scala
@@ -42,21 +42,19 @@ class EmailPreferenceController @Inject()(vatSubscriptionService: VatSubscriptio
                                           executionContext: ExecutionContext,
                                           inFlightPredicateComponents: InFlightPredicateComponents) extends BaseController {
 
-
   val formYesNo: Form[YesNo] = YesNoForm.yesNoForm("emailPreference.error")
-
 
   def show: Action[AnyContent] = (contactPreferencePredicate andThen
                                   paperPrefPredicate andThen
                                   inFlightContactPrefPredicate).async { implicit user =>
     if(appConfig.features.letterToConfirmedEmailEnabled()) {
-          Future.successful(Ok(emailPreferenceView(formYesNo))
-            .removingFromSession(SessionKeys.contactPrefUpdate)
-            .addingToSession(SessionKeys.currentContactPrefKey -> paper))
-        } else {
-          Future.successful(NotFound(errorHandler.notFoundTemplate))
-        }
-      }
+      Future.successful(Ok(emailPreferenceView(formYesNo))
+        .removingFromSession(SessionKeys.contactPrefUpdate)
+        .addingToSession(SessionKeys.currentContactPrefKey -> paper))
+    } else {
+      Future.successful(NotFound(errorHandler.notFoundTemplate))
+    }
+  }
 
   def submit: Action[AnyContent] = (contactPreferencePredicate andThen
                                     paperPrefPredicate andThen
@@ -75,7 +73,6 @@ class EmailPreferenceController @Inject()(vatSubscriptionService: VatSubscriptio
                      Redirect(controllers.contactPreference.routes.AddEmailAddressController.show())
                  }
                  result.addingToSession(SessionKeys.contactPrefUpdate -> "true")
-
 
               case Left(_) =>
               Logger.warn("[EmailPreferenceController][.submit] Unable to retrieve email address")

--- a/app/controllers/contactPreference/EmailToUseController.scala
+++ b/app/controllers/contactPreference/EmailToUseController.scala
@@ -93,8 +93,7 @@ class EmailToUseController @Inject()(val vatSubscriptionService: VatSubscription
                 Future.successful(BadRequest(emailToUseView(error, email))),
               {
                 case Yes => updateCommsPreference(user.vrn)
-                  //TODO: Update to be controllers.email.routes.CaptureEmailController.showPrefJourney()
-                case No => Future.successful(Redirect(controllers.contactPreference.routes.ChangeEmailController.show()))
+                case No => Future.successful(Redirect(controllers.email.routes.CaptureEmailController.showPrefJourney()))
               }
             )
             case _ => Future.successful(errorHandler.showInternalServerError)

--- a/app/controllers/contactPreference/EmailToUseController.scala
+++ b/app/controllers/contactPreference/EmailToUseController.scala
@@ -93,7 +93,8 @@ class EmailToUseController @Inject()(val vatSubscriptionService: VatSubscription
                 Future.successful(BadRequest(emailToUseView(error, email))),
               {
                 case Yes => updateCommsPreference(user.vrn)
-                case No => Future.successful(Redirect(controllers.email.routes.CaptureEmailController.show()))
+                  //TODO: Update to be controllers.email.routes.CaptureEmailController.showPrefJourney()
+                case No => Future.successful(Redirect(controllers.contactPreference.routes.ChangeEmailController.show()))
               }
             )
             case _ => Future.successful(errorHandler.showInternalServerError)

--- a/app/controllers/contactPreference/EmailToUseController.scala
+++ b/app/controllers/contactPreference/EmailToUseController.scala
@@ -66,7 +66,6 @@ class EmailToUseController @Inject()(val vatSubscriptionService: VatSubscription
             case Some(email) => Ok(emailToUseView(form, email))
               .addingToSession(SessionKeys.validationEmailKey -> email)
               .addingToSession(SessionKeys.prepopulationEmailKey -> email)
-              .removingFromSession(SessionKeys.contactPrefConfirmed)
             case _ => errorHandler.showInternalServerError
           }
 
@@ -110,8 +109,7 @@ class EmailToUseController @Inject()(val vatSubscriptionService: VatSubscription
     vatSubscriptionService.updateContactPreference(vrn, ContactPreference.digital) map {
     case Right(UpdatePPOBSuccess(_)) =>
       Redirect(controllers.contactPreference.routes.ContactPreferenceConfirmationController.show("email"))
-        .addingToSession( SessionKeys.letterToEmailChangeSuccessful -> "true",
-          SessionKeys.contactPrefConfirmed -> "true")
+        .addingToSession(SessionKeys.letterToEmailChangeSuccessful -> "true")
 
     case Left(ErrorModel(CONFLICT, _)) =>
       logWarn("[EmailToUseController][updateCommsPreference] - There is an update request " +

--- a/app/controllers/email/ConfirmEmailController.scala
+++ b/app/controllers/email/ConfirmEmailController.scala
@@ -52,32 +52,38 @@ class ConfirmEmailController @Inject()(val errorHandler: ErrorHandler,
     extractSessionEmail(user) match {
       case Some(email) =>
         Future.successful(Ok(
-          confirmEmailView(viewModel(email))
+          confirmEmailView(
+            CheckYourAnswersViewModel(
+              question = "checkYourAnswers.emailAddress",
+              answer = email,
+              changeLink = routes.CaptureEmailController.show().url,
+              changeLinkHiddenText = "checkYourAnswers.emailAddress.edit",
+              continueLink = routes.ConfirmEmailController.updateEmailAddress().url)
+          )
         ))
       case _ =>
         Future.successful(Redirect(routes.CaptureEmailController.show()))
     }
   }
 
-  def showNoExistingEmail: Action[AnyContent] = (blockAgentPredicate andThen inFlightEmailPredicate).async { implicit user =>
+  def showNoExistingEmail: Action[AnyContent] = (contactPreferencePredicate andThen paperPrefPredicate).async { implicit user =>
 
     extractSessionEmail(user) match {
       case Some(email) =>
         Future.successful(Ok(
-          confirmEmailView(viewModel(email))
+          confirmEmailView(
+            CheckYourAnswersViewModel(
+              question = "checkYourAnswers.emailAddress",
+              answer = email,
+              changeLink = controllers.contactPreference.routes.ChangeEmailController.show().url,
+              changeLinkHiddenText = "checkYourAnswers.emailAddress.edit",
+              continueLink = controllers.email.routes.VerifyEmailController.updateContactPrefEmail().url)
+          )
         ))
       case _ =>
         Future.successful(Redirect(routes.CaptureEmailController.show()))
     }
   }
-
-  def viewModel(email: String): CheckYourAnswersViewModel = CheckYourAnswersViewModel(
-                                                              question = "checkYourAnswers.emailAddress",
-                                                              answer = email,
-                                                              changeLink = routes.CaptureEmailController.show().url,
-                                                              changeLinkHiddenText = "checkYourAnswers.emailAddress.edit",
-                                                              continueLink = routes.ConfirmEmailController.updateEmailAddress().url
-  )
 
   def updateEmailAddress(): Action[AnyContent] = (blockAgentPredicate andThen inFlightEmailPredicate).async { implicit user =>
 

--- a/app/controllers/email/ConfirmEmailController.scala
+++ b/app/controllers/email/ConfirmEmailController.scala
@@ -75,7 +75,7 @@ class ConfirmEmailController @Inject()(val errorHandler: ErrorHandler,
             CheckYourAnswersViewModel(
               question = "checkYourAnswers.emailAddress",
               answer = email,
-              changeLink = controllers.contactPreference.routes.ChangeEmailController.show().url,
+              changeLink = controllers.email.routes.CaptureEmailController.showPrefJourney().url,
               changeLinkHiddenText = "checkYourAnswers.emailAddress.edit",
               continueLink = controllers.email.routes.VerifyEmailController.updateContactPrefEmail().url)
           )

--- a/app/controllers/email/VerifyEmailController.scala
+++ b/app/controllers/email/VerifyEmailController.scala
@@ -75,7 +75,7 @@ class VerifyEmailController @Inject()(val emailVerificationService: EmailVerific
 
   }
 
-  def contactPrefShow: Action[AnyContent] = (blockAgentPredicate) { implicit user =>
+  def contactPrefShow: Action[AnyContent] = (contactPreferencePredicate andThen paperPrefPredicate) { implicit user =>
 
     if (appConfig.features.letterToConfirmedEmailEnabled()) {
       extractSessionEmail match {
@@ -87,8 +87,7 @@ class VerifyEmailController @Inject()(val emailVerificationService: EmailVerific
     }
   }
 
-
-  def contactPrefSendVerification: Action[AnyContent] = blockAgentPredicate.async { implicit user =>
+  def contactPrefSendVerification: Action[AnyContent] = (contactPreferencePredicate andThen paperPrefPredicate).async { implicit user =>
 
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(user.headers, Some(user.session))
 
@@ -115,8 +114,6 @@ class VerifyEmailController @Inject()(val emailVerificationService: EmailVerific
       Future.successful(NotFound(errorHandler.notFoundTemplate))
     }
   }
-
-
 
   def updateContactPrefEmail(): Action[AnyContent] = (contactPreferencePredicate andThen paperPrefPredicate).async {
     implicit user =>

--- a/app/controllers/email/VerifyEmailController.scala
+++ b/app/controllers/email/VerifyEmailController.scala
@@ -139,6 +139,7 @@ class VerifyEmailController @Inject()(val emailVerificationService: EmailVerific
     vatSubscriptionService.updateContactPrefEmail(user.vrn, email).map {
       case Right(_) =>
         Redirect(controllers.email.routes.EmailChangeSuccessController.show())
+          .addingToSession(SessionKeys.emailChangeSuccessful -> "true")
       case Left(ErrorModel(CONFLICT, _)) =>
         logDebug("[EmailVerificationController][sendUpdateRequest] - There is a contact details update request " +
           "already in progress. Redirecting user to manage-vat overview page.")

--- a/app/views/contactPreference/AddEmailAddressView.scala.html
+++ b/app/views/contactPreference/AddEmailAddressView.scala.html
@@ -25,15 +25,14 @@
 
 @furtherContent = {
     <div>
-    <p> @messages("cPrefAddEmail.line1")</p>
-    <p> @messages("cPrefAddEmail.line2")</p>
+        <p> @messages("cPrefAddEmail.line1")</p>
+        <p> @messages("cPrefAddEmail.line2")</p>
 
-    <p>
-    <strong class="bold-small">
-        @messages("cPrefAddEmail.question")
-    </strong>
-    </p>
-
+        <p>
+            <strong class="bold-small">
+                @messages("cPrefAddEmail.question")
+            </strong>
+        </p>
     </div>
 }
 
@@ -45,23 +44,23 @@
 
     @errorSummary(messages("common.error.heading"), form)
 
-    @formWithCSRF(action = controllers.contactPreference.routes.AddEmailAddressController.show, 'novalidate -> "novalidate") {
+    @formWithCSRF(action = controllers.contactPreference.routes.AddEmailAddressController.submit, 'novalidate -> "novalidate") {
 
         <div id="@yesNo" class="form-group">
-         @radioGroup(
-        field = form(yesNo),
-        choices = Seq(
-        yes -> messages("common.yes"),
-        no  -> messages("common.no")),
-        question = messages("cPrefAddEmail.title"),
-        additionalContent = Some(furtherContent),
-        inline = false
-        )
+             @radioGroup(
+                field = form(yesNo),
+                choices = Seq(
+                    yes -> messages("common.yes"),
+                    no  -> messages("common.no")
+                ),
+                question = messages("cPrefAddEmail.title"),
+                additionalContent = Some(furtherContent),
+                inline = false
+            )
         </div>
 
         <button class="button" type="submit" id="continue">
-        @messages("common.continue")
-
+            @messages("common.continue")
         </button>
-        }
     }
+}

--- a/it/pages/contactPreference/EmailToUsePageSpec.scala
+++ b/it/pages/contactPreference/EmailToUsePageSpec.scala
@@ -171,7 +171,7 @@ class EmailToUsePageSpec extends BasePageISpec {
 
           res should have(
             httpStatus(Status.SEE_OTHER),
-            redirectURI(controllers.contactPreference.routes.ChangeEmailController.show().url)
+            redirectURI(controllers.email.routes.CaptureEmailController.showPrefJourney().url)
           )
         }
       }

--- a/it/pages/contactPreference/EmailToUsePageSpec.scala
+++ b/it/pages/contactPreference/EmailToUsePageSpec.scala
@@ -171,7 +171,7 @@ class EmailToUsePageSpec extends BasePageISpec {
 
           res should have(
             httpStatus(Status.SEE_OTHER),
-            redirectURI(controllers.email.routes.CaptureEmailController.show().url)
+            redirectURI(controllers.contactPreference.routes.ChangeEmailController.show().url)
           )
         }
       }

--- a/it/pages/email/VerifyEmailPageSpec.scala
+++ b/it/pages/email/VerifyEmailPageSpec.scala
@@ -17,6 +17,7 @@
 package pages.email
 
 import assets.BaseITConstants.internalServerErrorTitle
+import models.contactPreferences.ContactPreference.paper
 import pages.BasePageISpec
 import play.api.http.Status
 import play.api.libs.ws.WSResponse
@@ -240,7 +241,7 @@ class VerifyEmailPageSpec extends BasePageISpec {
 
       "there is an email in session" should {
 
-        def show: WSResponse = get(verifyContactPrefPath, formatEmail(Some(email)) ++ formatInflightChange(Some("false")))
+        def show: WSResponse = get(verifyContactPrefPath, formatEmail(Some(email)) ++ formatCurrentContactPref(Some(paper)))
 
         "render the verify email view" in {
 
@@ -262,7 +263,7 @@ class VerifyEmailPageSpec extends BasePageISpec {
 
     "there is not an email in session" should {
 
-      def show: WSResponse = get(verifyContactPrefPath, formatInflightChange(Some("false")))
+      def show: WSResponse = get(verifyContactPrefPath, formatCurrentContactPref(Some(paper)))
 
       "redirect to the contact preference redirect controller" in {
 
@@ -282,7 +283,7 @@ class VerifyEmailPageSpec extends BasePageISpec {
 
       def show: WSResponse = get(verifyContactPrefPath, formatEmail(Some(email)))
 
-      "render the Agent unauthorised view" in {
+      "redirect to client VAT account" in {
 
         given.user.isAuthenticatedAgent
 
@@ -290,8 +291,8 @@ class VerifyEmailPageSpec extends BasePageISpec {
         val result = show
 
         result should have(
-          httpStatus(Status.UNAUTHORIZED),
-          elementText("h1")("You cannot change your client’s email address yet")
+          httpStatus(Status.SEE_OTHER),
+          redirectURI("http://localhost:9149/vat-through-software/representative/client-vat-account")
         )
       }
     }
@@ -323,7 +324,7 @@ class VerifyEmailPageSpec extends BasePageISpec {
 
         "redirect to the verify email page" in {
 
-          def show: WSResponse = get(contactPrefSendVerificationPath, formatEmail(Some(email)) ++ formatInflightChange(Some("false")))
+          def show: WSResponse = get(contactPrefSendVerificationPath, formatEmail(Some(email)) ++ formatCurrentContactPref(Some(paper)))
 
           given.user.isAuthenticated
 
@@ -341,7 +342,7 @@ class VerifyEmailPageSpec extends BasePageISpec {
 
         "return a false from the Email Verification service" should {
 
-          def show: WSResponse = get(contactPrefSendVerificationPath, formatEmail(Some(email)) ++ formatInflightChange(Some("false")))
+          def show: WSResponse = get(contactPrefSendVerificationPath, formatEmail(Some(email)) ++ formatCurrentContactPref(Some(paper)))
 
           "redirect to the Confirm Email controller" in {
 
@@ -362,7 +363,7 @@ class VerifyEmailPageSpec extends BasePageISpec {
 
         "return None from the Email Verification service" should {
 
-          def show: WSResponse = get(contactPrefSendVerificationPath, formatEmail(Some(email)) ++ formatInflightChange(Some("false")))
+          def show: WSResponse = get(contactPrefSendVerificationPath, formatEmail(Some(email)) ++ formatCurrentContactPref(Some(paper)))
 
           "render the internal server error page" in {
 
@@ -384,9 +385,9 @@ class VerifyEmailPageSpec extends BasePageISpec {
 
       "there is not an email in session" should {
 
-        def show: WSResponse = get(contactPrefSendVerificationPath, formatInflightChange(Some("false")))
+        def show: WSResponse = get(contactPrefSendVerificationPath, formatCurrentContactPref(Some(paper)))
 
-        "redirect to the congtact preference redirect controller" in {
+        "redirect to the contact preference redirect controller" in {
 
           given.user.isAuthenticated
 
@@ -405,7 +406,7 @@ class VerifyEmailPageSpec extends BasePageISpec {
 
       def show: WSResponse = get(contactPrefSendVerificationPath, formatEmail(Some(email)))
 
-      "render the unauthorised view" in {
+      "redirect to client VAT account" in {
 
         given.user.isAuthenticatedAgent
 
@@ -413,8 +414,8 @@ class VerifyEmailPageSpec extends BasePageISpec {
         val result = show
 
         result should have(
-          httpStatus(Status.UNAUTHORIZED),
-          elementText("h1")("You cannot change your client’s email address yet")
+          httpStatus(Status.SEE_OTHER),
+          redirectURI("http://localhost:9149/vat-through-software/representative/client-vat-account")
         )
       }
     }

--- a/test/controllers/contactPreference/EmailToUseControllerSpec.scala
+++ b/test/controllers/contactPreference/EmailToUseControllerSpec.scala
@@ -240,7 +240,7 @@ class EmailToUseControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        s"Redirect to the '${controllers.email.routes.CaptureEmailController.show().url}'" in {
+        s"Redirect to the '${controllers.email.routes.CaptureEmailController.showPrefJourney().url}'" in {
           redirectLocation(result) shouldBe Some(controllers.email.routes.CaptureEmailController.showPrefJourney().url)
         }
       }

--- a/test/controllers/contactPreference/EmailToUseControllerSpec.scala
+++ b/test/controllers/contactPreference/EmailToUseControllerSpec.scala
@@ -45,8 +45,7 @@ class EmailToUseControllerSpec extends ControllerBaseSpec {
   lazy val existingEmailSessionRequest: FakeRequest[AnyContentAsEmpty.type] =
     requestWithPaperPref.withSession(
       SessionKeys.validationEmailKey -> testValidationEmail,
-      SessionKeys.contactPrefUpdate -> "true",
-      SessionKeys.contactPrefConfirmed -> "true"
+      SessionKeys.contactPrefUpdate -> "true"
     )
 
   lazy val noEmailSessionRequest: FakeRequest[AnyContentAsEmpty.type] =
@@ -89,10 +88,6 @@ class EmailToUseControllerSpec extends ControllerBaseSpec {
         "add the email address to session" in {
           session(result).get(SessionKeys.validationEmailKey) shouldBe Some(testValidationEmail)
           session(result).get(SessionKeys.prepopulationEmailKey) shouldBe Some(testValidationEmail)
-        }
-
-        s"not contain the ${SessionKeys.contactPrefConfirmed} key" in {
-          session(result).get(SessionKeys.contactPrefConfirmed) shouldBe None
         }
       }
 

--- a/test/controllers/contactPreference/EmailToUseControllerSpec.scala
+++ b/test/controllers/contactPreference/EmailToUseControllerSpec.scala
@@ -241,7 +241,7 @@ class EmailToUseControllerSpec extends ControllerBaseSpec {
         }
 
         s"Redirect to the '${controllers.email.routes.CaptureEmailController.show().url}'" in {
-          redirectLocation(result) shouldBe Some(controllers.email.routes.CaptureEmailController.show().url)
+          redirectLocation(result) shouldBe Some(controllers.contactPreference.routes.ChangeEmailController.show().url)
         }
       }
 

--- a/test/controllers/contactPreference/EmailToUseControllerSpec.scala
+++ b/test/controllers/contactPreference/EmailToUseControllerSpec.scala
@@ -241,7 +241,7 @@ class EmailToUseControllerSpec extends ControllerBaseSpec {
         }
 
         s"Redirect to the '${controllers.email.routes.CaptureEmailController.show().url}'" in {
-          redirectLocation(result) shouldBe Some(controllers.contactPreference.routes.ChangeEmailController.show().url)
+          redirectLocation(result) shouldBe Some(controllers.email.routes.CaptureEmailController.showPrefJourney().url)
         }
       }
 

--- a/test/controllers/email/ConfirmEmailControllerSpec.scala
+++ b/test/controllers/email/ConfirmEmailControllerSpec.scala
@@ -144,7 +144,7 @@ class ConfirmEmailControllerSpec extends ControllerBaseSpec  {
 
         "has the correct change link URL" in {
           page.select(".cya-change a").attr("href") shouldBe
-            controllers.contactPreference.routes.ChangeEmailController.show().url
+            controllers.email.routes.CaptureEmailController.showPrefJourney().url
         }
 
         "has the correct hidden text" in {

--- a/test/controllers/email/VerifyEmailControllerSpec.scala
+++ b/test/controllers/email/VerifyEmailControllerSpec.scala
@@ -372,6 +372,10 @@ class VerifyEmailControllerSpec extends ControllerBaseSpec with MockEmailVerific
         "redirects to the correct page" in {
           redirectLocation(result) shouldBe Some(controllers.email.routes.EmailChangeSuccessController.show().url)
         }
+
+        "add emailChangeSuccessful to session" in {
+          session(result).get(SessionKeys.emailChangeSuccessful) shouldBe Some("true")
+        }
       }
     }
 

--- a/test/controllers/email/VerifyEmailControllerSpec.scala
+++ b/test/controllers/email/VerifyEmailControllerSpec.scala
@@ -28,8 +28,8 @@ import play.api.test.Helpers._
 import views.html.email.VerifyEmailView
 import assets.BaseTestConstants.vrn
 import models.errors.ErrorModel
-
 import scala.concurrent.Future
+import models.contactPreferences.ContactPreference._
 
 class VerifyEmailControllerSpec extends ControllerBaseSpec with MockEmailVerificationService {
 
@@ -189,7 +189,7 @@ class VerifyEmailControllerSpec extends ControllerBaseSpec with MockEmailVerific
 
       lazy val result = {
         mockConfig.features.letterToConfirmedEmailEnabled(true)
-        TestVerifyEmailController.contactPrefShow()(requestWithEmail)
+        TestVerifyEmailController.contactPrefShow()(requestWithEmail.withSession(SessionKeys.currentContactPrefKey -> paper))
       }
 
       "return 200 (OK)" in {
@@ -206,7 +206,7 @@ class VerifyEmailControllerSpec extends ControllerBaseSpec with MockEmailVerific
 
       lazy val result = {
         mockConfig.features.letterToConfirmedEmailEnabled(true)
-        TestVerifyEmailController.contactPrefShow()(emptyEmailSessionRequest)
+        TestVerifyEmailController.contactPrefShow()(emptyEmailSessionRequest.withSession(SessionKeys.currentContactPrefKey -> paper))
       }
 
       "return 303 (SEE_OTHER)" in {
@@ -234,7 +234,7 @@ class VerifyEmailControllerSpec extends ControllerBaseSpec with MockEmailVerific
 
       lazy val result = {
         mockConfig.features.letterToConfirmedEmailEnabled(false)
-        TestVerifyEmailController.contactPrefShow()(requestWithEmail)
+        TestVerifyEmailController.contactPrefShow()(requestWithEmail.withSession(SessionKeys.currentContactPrefKey -> paper))
       }
 
       "return page not found (404)" in {
@@ -250,7 +250,7 @@ class VerifyEmailControllerSpec extends ControllerBaseSpec with MockEmailVerific
       lazy val result = {
         mockConfig.features.letterToConfirmedEmailEnabled(true)
         mockGetEmailVerificationState(testEmail)(Future.successful(Some(true)))
-        TestVerifyEmailController.contactPrefSendVerification()(requestWithEmail)
+        TestVerifyEmailController.contactPrefSendVerification()(requestWithEmail.withSession(SessionKeys.currentContactPrefKey -> paper))
       }
 
       "return 303 (SEE_OTHER)" in {
@@ -266,7 +266,7 @@ class VerifyEmailControllerSpec extends ControllerBaseSpec with MockEmailVerific
       lazy val result = {
         mockGetEmailVerificationState(testEmail)(Future.successful(Some(false)))
         mockCreateEmailVerificationRequest(Some(false))
-        TestVerifyEmailController.contactPrefSendVerification()(requestWithEmail)
+        TestVerifyEmailController.contactPrefSendVerification()(requestWithEmail.withSession(SessionKeys.currentContactPrefKey -> paper))
       }
 
       s"has a status of $SEE_OTHER" in {
@@ -284,7 +284,7 @@ class VerifyEmailControllerSpec extends ControllerBaseSpec with MockEmailVerific
         mockConfig.features.letterToConfirmedEmailEnabled(true)
         mockGetEmailVerificationState(testEmail)(Future.successful(Some(false)))
         mockCreateEmailVerificationRequest(Some(true))
-        TestVerifyEmailController.contactPrefSendVerification()(requestWithEmail)
+        TestVerifyEmailController.contactPrefSendVerification()(requestWithEmail.withSession(SessionKeys.currentContactPrefKey -> paper))
       }
 
       "return 303 (SEE_OTHER)" in {
@@ -302,7 +302,7 @@ class VerifyEmailControllerSpec extends ControllerBaseSpec with MockEmailVerific
         mockConfig.features.letterToConfirmedEmailEnabled(true)
         mockGetEmailVerificationState(testEmail)(Future.successful(Some(false)))
         mockCreateEmailVerificationRequest(None)
-        TestVerifyEmailController.contactPrefSendVerification()(requestWithEmail)
+        TestVerifyEmailController.contactPrefSendVerification()(requestWithEmail.withSession(SessionKeys.currentContactPrefKey -> paper))
       }
 
       "return 500 (INTERNAL_SERVER_ERROR)" in {
@@ -313,7 +313,7 @@ class VerifyEmailControllerSpec extends ControllerBaseSpec with MockEmailVerific
     "there isn't an email in session" should {
 
       lazy val result = {
-        TestVerifyEmailController.contactPrefSendVerification()(emptyEmailSessionRequest)
+        TestVerifyEmailController.contactPrefSendVerification()(emptyEmailSessionRequest.withSession(SessionKeys.currentContactPrefKey -> paper))
       }
 
       "return 303 (SEE_OTHER)" in {
@@ -341,7 +341,7 @@ class VerifyEmailControllerSpec extends ControllerBaseSpec with MockEmailVerific
 
       lazy val result = {
         mockConfig.features.letterToConfirmedEmailEnabled(false)
-        TestVerifyEmailController.contactPrefSendVerification()(requestWithEmail)
+        TestVerifyEmailController.contactPrefSendVerification()(requestWithEmail.withSession(SessionKeys.currentContactPrefKey -> paper))
       }
 
       "return page not found (404)" in {
@@ -419,7 +419,7 @@ class VerifyEmailControllerSpec extends ControllerBaseSpec with MockEmailVerific
 
       lazy val result = {
         mockConfig.features.letterToConfirmedEmailEnabled(false)
-        TestVerifyEmailController.contactPrefSendVerification()(requestWithEmail)
+        TestVerifyEmailController.contactPrefSendVerification()(requestWithEmail.withSession(SessionKeys.currentContactPrefKey -> paper))
       }
 
       "return page not found (404)" in {

--- a/test/views/contactPreference/AddEmailAddressViewSpec.scala
+++ b/test/views/contactPreference/AddEmailAddressViewSpec.scala
@@ -30,6 +30,7 @@ class AddEmailAddressViewSpec extends ViewBaseSpec {
   object Selectors {
     val pageHeading = "#content h1"
     val backLink = "#content > article > a"
+    val form = "form"
     val button = ".button"
     val line1 = "#yes_no > div:nth-child(1) > fieldset:nth-child(1) > div:nth-child(2) > p:nth-child(1)"
     val line2 = "#yes_no > div:nth-child(1) > fieldset:nth-child(1) > div:nth-child(2) > p:nth-child(2)"
@@ -40,6 +41,7 @@ class AddEmailAddressViewSpec extends ViewBaseSpec {
   }
 
   "Once rendered, the add email address page" should {
+
     lazy val view = addEmailView(YesNoForm.yesNoForm(ContactPrefAddEmailMessages.title))(user, messages, mockConfig)
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
@@ -65,51 +67,45 @@ class AddEmailAddressViewSpec extends ViewBaseSpec {
       "should have the correct href" in {
         element(Selectors.backLink).attr("href") shouldBe routes.EmailPreferenceController.show().url
       }
-
-
-      "have the correct continue button text" in {
-        elementText(Selectors.button) shouldBe ContactPrefAddEmailMessages.continue
-      }
-
-      "have the correct radio buttons with yes/no answers" in {
-        elementText(Selectors.yesOption) shouldBe ContactPrefAddEmailMessages.yes
-        elementText(Selectors.noOption) shouldBe ContactPrefAddEmailMessages.no
-      }
-
-      "not display an error" in {
-        document.select(Selectors.error).isEmpty shouldBe true
-      }
     }
 
-    "The add email address page with errors" should {
-      lazy val view = addEmailView(YesNoForm.yesNoForm(ContactPrefAddEmailMessages.errorMessage).bind(Map("yes_no" -> "")))(
-        user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
+    "have the correct continue button text" in {
+      elementText(Selectors.button) shouldBe ContactPrefAddEmailMessages.continue
+    }
 
-      "have the correct document title" in {
-        document.title shouldBe s"${ContactPrefAddEmailMessages.errorTitlePrefix} ${ContactPrefAddEmailMessages.title}"
-      }
+    "have the correct radio buttons with yes/no answers" in {
+      elementText(Selectors.yesOption) shouldBe ContactPrefAddEmailMessages.yes
+      elementText(Selectors.noOption) shouldBe ContactPrefAddEmailMessages.no
+    }
 
-      "have the correct page heading" in {
-        elementText(Selectors.pageHeading) shouldBe ContactPrefAddEmailMessages.heading
-      }
+    "not display an error" in {
+      document.select(Selectors.error).isEmpty shouldBe true
+    }
 
-      "display the correct error heading" in {
-        elementText(Selectors.errorHeading) shouldBe s"${ContactPrefAddEmailMessages.errorHeading} ${ContactPrefAddEmailMessages.errorMessage}"
-      }
+    "have the correct submit action URL" in {
+      element(Selectors.form).attr("action") shouldBe controllers.contactPreference.routes.AddEmailAddressController.submit().url
+    }
+  }
 
-      "have the correct radio buttons with yes/no answers" in {
-        elementText(Selectors.yesOption) shouldBe ContactPrefAddEmailMessages.yes
-        elementText(Selectors.noOption) shouldBe ContactPrefAddEmailMessages.no
-      }
+  "The add email address page with errors" should {
+    lazy val view = addEmailView(YesNoForm.yesNoForm(ContactPrefAddEmailMessages.errorMessage).bind(Map("yes_no" -> "")))(
+      user, messages, mockConfig)
+    lazy implicit val document: Document = Jsoup.parse(view.body)
 
-      "have the correct continue button text" in {
-        elementText(Selectors.button) shouldBe ContactPrefAddEmailMessages.continue
-      }
+    "have the correct document title" in {
+      document.title shouldBe s"${ContactPrefAddEmailMessages.errorTitlePrefix} ${ContactPrefAddEmailMessages.title}"
+    }
 
-      "display the correct error message" in {
-        elementText(Selectors.error) shouldBe ContactPrefAddEmailMessages.errorMessage
-      }
+    "have the correct page heading" in {
+      elementText(Selectors.pageHeading) shouldBe ContactPrefAddEmailMessages.heading
+    }
+
+    "display the correct error heading" in {
+      elementText(Selectors.errorHeading) shouldBe s"${ContactPrefAddEmailMessages.errorHeading} ${ContactPrefAddEmailMessages.errorMessage}"
+    }
+
+    "display the correct error message" in {
+      elementText(Selectors.error) shouldBe ContactPrefAddEmailMessages.errorMessage
     }
   }
 }


### PR DESCRIPTION
- Fixed submit route for add email address page
- Removed usage of 'contactPrefConfirmed' session key
- Updated new controller actions to use `contactPreferencePredicate` instead of `blockAgentPredicate`
- Corrected forward routing on ConfirmEmailController to be dynamic (goes to either normal email verification or contact pref email verification journeys) and added missing tests
- Corrected forward routing on EmailToUse controller to go to new capture email page
- Refactoring CaptureEmailController to remove warnings

**Please merge at same time as acceptance tests**