### PR TITLE
BTAT-8181 Added audit model for attempted new email entry in pref journey

### DIFF
--- a/app/audit/models/AttemptedContactPrefEmailAuditModel.scala
+++ b/app/audit/models/AttemptedContactPrefEmailAuditModel.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit.models
+
+import models.contactPreferences.ContactPreference
+import play.api.libs.json.{JsValue, Json, Writes}
+import utils.JsonObjectSugar
+
+case class AttemptedContactPrefEmailAuditModel(currentEmailAddress: Option[String],
+                                               requestedEmailAddress: String,
+                                               vrn: String) extends AuditModel {
+  override val auditType: String = "ChangeContactPreferenceAndEmailAttempted"
+  override val detail: JsValue = Json.toJson(this)
+  override val transactionName: String = "change-vat-contact-preference-and-email-attempted"
+}
+
+object AttemptedContactPrefEmailAuditModel extends JsonObjectSugar {
+
+  implicit val writes: Writes[AttemptedContactPrefEmailAuditModel] = Writes { model =>
+    jsonObjNoNulls(
+      "currentEmailAddress" -> model.currentEmailAddress,
+      "requestedEmailAddress" -> model.requestedEmailAddress,
+      "currentContactPreference" -> ContactPreference.paper,
+      "requestedContactPreference" -> ContactPreference.digital,
+      "vrn" -> model.vrn
+    )
+  }
+}

--- a/app/controllers/email/CaptureEmailController.scala
+++ b/app/controllers/email/CaptureEmailController.scala
@@ -162,7 +162,7 @@ class CaptureEmailController @Inject()(val vatSubscriptionService: VatSubscripti
               ),
               controllers.email.routes.CaptureEmailController.submitPrefJourney().url
             )
-            Future.successful(Redirect(controllers.email.routes.ConfirmEmailController.showNoExistingEmail())
+            Future.successful(Redirect(controllers.email.routes.ConfirmEmailController.showContactPref())
               .addingToSession(SessionKeys.prepopulationEmailKey -> email))
           }
         )

--- a/app/controllers/email/CaptureEmailController.scala
+++ b/app/controllers/email/CaptureEmailController.scala
@@ -17,7 +17,7 @@
 package controllers.email
 
 import audit.AuditingService
-import audit.models.AttemptedEmailAddressAuditModel
+import audit.models.{AttemptedContactPrefEmailAuditModel, AttemptedEmailAddressAuditModel}
 import common.SessionKeys
 import config.{AppConfig, ErrorHandler}
 import controllers.BaseController
@@ -155,12 +155,10 @@ class CaptureEmailController @Inject()(val vatSubscriptionService: VatSubscripti
           },
           email     => {
             auditService.extendedAudit(
-              AttemptedEmailAddressAuditModel(
+              AttemptedContactPrefEmailAuditModel(
                 Option(validation).filter(_.nonEmpty),
                 email,
-                user.vrn,
-                user.isAgent,
-                user.arn
+                user.vrn
               ),
               controllers.email.routes.CaptureEmailController.submitPrefJourney().url
             )

--- a/app/controllers/email/ConfirmEmailController.scala
+++ b/app/controllers/email/ConfirmEmailController.scala
@@ -47,11 +47,11 @@ class ConfirmEmailController @Inject()(val errorHandler: ErrorHandler,
 
   implicit val ec: ExecutionContext = mcc.executionContext
 
-  def show: Action[AnyContent] = (blockAgentPredicate andThen inFlightEmailPredicate).async { implicit user =>
+  def show: Action[AnyContent] = (blockAgentPredicate andThen inFlightEmailPredicate){ implicit user =>
 
     extractSessionEmail(user) match {
       case Some(email) =>
-        Future.successful(Ok(
+        Ok(
           confirmEmailView(
             CheckYourAnswersViewModel(
               question = "checkYourAnswers.emailAddress",
@@ -60,19 +60,19 @@ class ConfirmEmailController @Inject()(val errorHandler: ErrorHandler,
               changeLinkHiddenText = "checkYourAnswers.emailAddress.edit",
               continueLink = routes.ConfirmEmailController.updateEmailAddress().url)
           )
-        ))
+        )
       case _ =>
-        Future.successful(Redirect(routes.CaptureEmailController.show()))
+        Redirect(routes.CaptureEmailController.show())
     }
   }
 
-  def showNoExistingEmail: Action[AnyContent] = (
+  def showContactPref: Action[AnyContent] = (
     contactPreferencePredicate andThen paperPrefPredicate andThen inFlightContactPrefPredicate
-    ).async { implicit user =>
+    ) { implicit user =>
 
     extractSessionEmail(user) match {
       case Some(email) =>
-        Future.successful(Ok(
+        Ok(
           confirmEmailView(
             CheckYourAnswersViewModel(
               question = "checkYourAnswers.emailAddress",
@@ -81,9 +81,9 @@ class ConfirmEmailController @Inject()(val errorHandler: ErrorHandler,
               changeLinkHiddenText = "checkYourAnswers.emailAddress.edit",
               continueLink = controllers.email.routes.VerifyEmailController.updateContactPrefEmail().url)
           )
-        ))
+        )
       case _ =>
-        Future.successful(Redirect(routes.CaptureEmailController.show()))
+        Redirect(routes.CaptureEmailController.show())
     }
   }
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -15,7 +15,7 @@ GET         /update-email-address                            controllers.email.C
 GET         /contact-preference/update-email-address         controllers.email.VerifyEmailController.updateContactPrefEmail
 
 # confirm email address where there is no existing email
-GET         /contact-preference/confirm-email-address        controllers.email.ConfirmEmailController.showNoExistingEmail
+GET         /contact-preference/confirm-email-address        controllers.email.ConfirmEmailController.showContactPref
 
 # verify email address
 GET         /verify-email-address                       controllers.email.VerifyEmailController.emailShow

--- a/test/audit/models/AttemptedContactPrefEmailAuditModelSpec.scala
+++ b/test/audit/models/AttemptedContactPrefEmailAuditModelSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit.models
+
+import play.api.libs.json.Json
+import uk.gov.hmrc.play.test.UnitSpec
+
+class AttemptedContactPrefEmailAuditModelSpec extends UnitSpec {
+
+  val auditModelWithEmail: AttemptedContactPrefEmailAuditModel = AttemptedContactPrefEmailAuditModel(
+    currentEmailAddress = Some("vim@test.com"),
+    requestedEmailAddress = "nano@test.com",
+    vrn = "999999999"
+  )
+
+  val auditModelNoEmail: AttemptedContactPrefEmailAuditModel = auditModelWithEmail.copy(currentEmailAddress = None)
+
+  "AttemptedContactPrefEmailAuditModel" when {
+
+    "there is a current email address" should {
+
+      "have the correct JSON detail" in {
+
+        val expectedJson = Json.obj(
+          "currentEmailAddress" -> "vim@test.com",
+          "requestedEmailAddress" -> "nano@test.com",
+          "currentContactPreference" -> "PAPER",
+          "requestedContactPreference" -> "DIGITAL",
+          "vrn" -> "999999999"
+        )
+
+        auditModelWithEmail.detail shouldBe expectedJson
+      }
+    }
+
+    "there is no current email address" should {
+
+      "have the correct JSON detail" in {
+
+        val expectedJson = Json.obj(
+          "requestedEmailAddress" -> "nano@test.com",
+          "currentContactPreference" -> "PAPER",
+          "requestedContactPreference" -> "DIGITAL",
+          "vrn" -> "999999999"
+        )
+
+        auditModelNoEmail.detail shouldBe expectedJson
+      }
+    }
+  }
+}

--- a/test/controllers/email/CaptureEmailControllerSpec.scala
+++ b/test/controllers/email/CaptureEmailControllerSpec.scala
@@ -468,7 +468,7 @@ class CaptureEmailControllerSpec extends ControllerBaseSpec {
             }
             "redirect to the confirm email view" in {
               status(result) shouldBe Status.SEE_OTHER
-              redirectLocation(result) shouldBe Some(controllers.email.routes.ConfirmEmailController.showNoExistingEmail().url)
+              redirectLocation(result) shouldBe Some(controllers.email.routes.ConfirmEmailController.showContactPref().url)
             }
 
             "add the new email to the session" in {

--- a/test/controllers/email/ConfirmEmailControllerSpec.scala
+++ b/test/controllers/email/ConfirmEmailControllerSpec.scala
@@ -119,12 +119,12 @@ class ConfirmEmailControllerSpec extends ControllerBaseSpec  {
     }
   }
 
-  "Calling the showNoExistingEmail action in ConfirmEmailController" when {
+  "Calling the showContactPref action in ConfirmEmailController" when {
 
     "there is an email in session" should {
 
       mockIndividualAuthorised()
-      lazy val result = TestConfirmEmailController.showNoExistingEmail(requestWithEmail.withSession(SessionKeys.currentContactPrefKey -> paper))
+      lazy val result = TestConfirmEmailController.showContactPref(requestWithEmail.withSession(SessionKeys.currentContactPrefKey -> paper))
 
       "return OK" in {
         status(result) shouldBe Status.OK
@@ -162,7 +162,7 @@ class ConfirmEmailControllerSpec extends ControllerBaseSpec  {
 
       lazy val result = {
         mockIndividualAuthorised()
-        TestConfirmEmailController.showNoExistingEmail(request.withSession(SessionKeys.currentContactPrefKey -> paper))
+        TestConfirmEmailController.showContactPref(request.withSession(SessionKeys.currentContactPrefKey -> paper))
       }
 
       "return 303" in {
@@ -178,7 +178,7 @@ class ConfirmEmailControllerSpec extends ControllerBaseSpec  {
 
       "return forbidden (403)" in {
         mockIndividualWithoutEnrolment()
-        val result = TestConfirmEmailController.showNoExistingEmail(requestWithEmail)
+        val result = TestConfirmEmailController.showContactPref(requestWithEmail)
 
         status(result) shouldBe Status.FORBIDDEN
       }


### PR DESCRIPTION
I have also corrected one of the unit tests for `submitPrefJourney` action, and added an extra unit test to both submit actions in the relevant controller to verify the audit event/model.