### PR TITLE
BTAT-8243 Addressed error summary/message issues raised by pre-audit

### DIFF
--- a/app/views/contactPreference/AddEmailAddressView.scala.html
+++ b/app/views/contactPreference/AddEmailAddressView.scala.html
@@ -25,7 +25,7 @@
 
 @furtherContent = {
     <div>
-        <p> @messages("cPrefAddEmail.line1")</p>
+        <p id="form-hint"> @messages("cPrefAddEmail.line1")</p>
         <p> @messages("cPrefAddEmail.line2")</p>
 
         <p>
@@ -46,18 +46,16 @@
 
     @formWithCSRF(action = controllers.contactPreference.routes.AddEmailAddressController.submit, 'novalidate -> "novalidate") {
 
-        <div id="@yesNo" class="form-group">
-             @radioGroup(
-                field = form(yesNo),
-                choices = Seq(
-                    yes -> messages("common.yes"),
-                    no  -> messages("common.no")
-                ),
-                question = messages("cPrefAddEmail.title"),
-                additionalContent = Some(furtherContent),
-                inline = false
-            )
-        </div>
+         @radioGroup(
+            field = form(yesNo),
+            choices = Seq(
+                yes -> messages("common.yes"),
+                no  -> messages("common.no")
+            ),
+            question = messages("cPrefAddEmail.title"),
+            additionalContent = Some(furtherContent),
+            inline = false
+        )
 
         <button class="button" type="submit" id="continue">
             @messages("common.continue")

--- a/app/views/contactPreference/EmailPreferenceView.scala.html
+++ b/app/views/contactPreference/EmailPreferenceView.scala.html
@@ -24,7 +24,7 @@
 @(form: Form[YesNo])(implicit user: User[_], messages: Messages, appConfig: config.AppConfig)
 
 @questionContent = {
-  <div class="panel panel-border-wide">
+  <div id="form-hint" class="panel panel-border-wide">
     @messages("emailPreference.hint")
   </div>
 }
@@ -38,7 +38,6 @@
     <a class="link-back" href="@appConfig.btaAccountDetailsUrl">@messages("base.back")</a>
 
   @formWithCSRF(action = controllers.contactPreference.routes.EmailPreferenceController.submit, 'novalidate -> "novalidate") {
-    <div id="@yesNo" class="form-group">
       @radioGroup(
         field = form(yesNo),
         choices = Seq(
@@ -48,7 +47,6 @@
         additionalContent = Some(questionContent),
         inline = false
       )
-    </div>
 
     <button class="button" type="submit" id="continue">
       @messages("common.continue")

--- a/app/views/contactPreference/EmailToUseView.scala.html
+++ b/app/views/contactPreference/EmailToUseView.scala.html
@@ -24,7 +24,7 @@
 @(emailToUseForm: Form[YesNo], emailAddress: String)(implicit user: User[_], messages: Messages, appConfig: config.AppConfig)
 
 @questionContent = {
-    <div class="panel panel-border-wide">
+    <div id="form-hint" class="panel panel-border-wide">
         @emailAddress
     </div>
 }
@@ -39,16 +39,14 @@
 
     @form(action = controllers.contactPreference.routes.EmailToUseController.submit, 'novalidate -> "novalidate") {
 
-        <div id="@yesNo" class="form-group">
-            @radioGroup(
-                field = emailToUseForm(yesNo),
-                choices = Seq(
-                yes -> messages("common.yes"),
-                no -> messages("common.no")),
-                question = messages("emailToUse.title"),
-                additionalContent = Some(questionContent)
-            )
-        </div>
+        @radioGroup(
+            field = emailToUseForm(yesNo),
+            choices = Seq(
+            yes -> messages("common.yes"),
+            no -> messages("common.no")),
+            question = messages("emailToUse.title"),
+            additionalContent = Some(questionContent)
+        )
 
         <button class="button" type ="submit" id="continue">
             @messages("common.continue")

--- a/app/views/contactPreference/LetterPreferenceView.scala.html
+++ b/app/views/contactPreference/LetterPreferenceView.scala.html
@@ -25,7 +25,7 @@
 
 @hint = {
   <div class="panel panel-border-wide">
-    <p>@messages("letterPreference.hint")</p>
+    <p id="form-hint">@messages("letterPreference.hint")</p>
   </div>
 }
 
@@ -39,7 +39,6 @@
 
     @formWithCSRF(action = controllers.contactPreference.routes.LetterPreferenceController.submit,
     'novalidate -> "novalidate") {
-    <div id="@yesNo" class="form-group">
       @radioGroup(
         field = form(yesNo),
         choices = Seq(
@@ -50,7 +49,6 @@
         additionalContent = Some(hint),
         inline = false
       )
-    </div>
 
     <button class="button" type="submit" id="continue">
       @messages("common.continue")

--- a/app/views/email/CaptureEmailView.scala.html
+++ b/app/views/email/CaptureEmailView.scala.html
@@ -16,7 +16,6 @@
 
 @import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 @import config.AppConfig
-@import forms.EmailForm._
 @import views.html.templates.inputs.Text
 @import views.html.templates.errors.ErrorSummary
 @import play.api.mvc.Call
@@ -26,10 +25,10 @@
 @(emailForm: Form[String], emailNotChangedError: Boolean, currentEmail: String, submitFormAction: Call, letterToConfirmedEmail: Boolean)(implicit user: User[_], messages: Messages, appConfig: AppConfig)
 
 @additionalContent = {
-    @if(currentEmail == "") {
+  @if(currentEmail == "") {
     <p>@messages("captureEmail.onlyAddEmail")</p>
-    }
-  <span class="form-hint">@messages("captureEmail.hint")</span>
+  }
+  <span id="form-hint" class="form-hint">@messages("captureEmail.hint")</span>
 }
 
 @mainTemplate(if(emailForm.errors.nonEmpty) messages("common.error.prefixTitle", messages("captureEmail.title")) else messages("captureEmail.title")) {
@@ -37,9 +36,9 @@
     @if(letterToConfirmedEmail){
         @currentEmail match {
         case "" => {
-        <a class="link-back" href="@controllers.contactPreference.routes.AddEmailAddressController.show().url">@messages("base.back")</a>}
+          <a class="link-back" href="@controllers.contactPreference.routes.AddEmailAddressController.show().url">@messages("base.back")</a>}
         case _ => {
-        <a class="link-back" href="@controllers.contactPreference.routes.EmailToUseController.show().url">@messages("base.back")</a>}
+          <a class="link-back" href="@controllers.contactPreference.routes.EmailToUseController.show().url">@messages("base.back")</a>}
         }
 
     } else {<a class="link-back" href="@appConfig.dynamicJourneyEntryUrl(user.isAgent)">@messages("base.back")</a>}
@@ -48,13 +47,11 @@
         @errorSummary(messages("common.error.heading"), emailForm)
 
         @form(action = submitFormAction) {
-            <div class="form-group">
             @text(
                 field = emailForm("email"),
                 pageTitle = messages("captureEmail.title"),
                 additionalContent = Some(additionalContent)
             )
-            </div>
 
             <div class="form-group">
                 <button class="button" type="submit">@messages("common.continue")</button>

--- a/app/views/landlineNumber/CaptureLandlineNumberView.scala.html
+++ b/app/views/landlineNumber/CaptureLandlineNumberView.scala.html
@@ -24,7 +24,7 @@
 @(landlineForm: Form[String], currentLandline: String)(implicit user: User[_], messages: Messages, appConfig: AppConfig)
 
 @formHint = {
-  <span class="form-hint">@messages("captureLandline.hint")</span>
+  <span id="form-hint" class="form-hint">@messages("captureLandline.hint")</span>
 }
 
 @mainTemplate(
@@ -37,13 +37,11 @@
     @errorSummary(messages("common.error.heading"), landlineForm)
 
     @form(action = controllers.landlineNumber.routes.CaptureLandlineNumberController.submit) {
-        <div class="form-group">
         @text(
             field = landlineForm("landlineNumber"),
             pageTitle = messages("captureLandline.title"),
             additionalContent = Some(formHint)
         )
-        </div>
 
         @if(currentLandline != "") {
             <p><a id="remove-landline" href='@controllers.landlineNumber.routes.ConfirmRemoveLandlineController.show().url'>

--- a/app/views/mobileNumber/CaptureMobileNumberView.scala.html
+++ b/app/views/mobileNumber/CaptureMobileNumberView.scala.html
@@ -24,7 +24,7 @@
 @(mobileNumberForm: Form[String], currentMobile: String)(implicit user: User[_], messages: Messages, appConfig: AppConfig)
 
 @formHint = {
-  <span class="form-hint">@messages("captureMobile.hint")</span>
+  <span id="form-hint" class="form-hint">@messages("captureMobile.hint")</span>
 }
 
 @mainTemplate(
@@ -38,13 +38,11 @@
 
     @form(action = controllers.mobileNumber.routes.CaptureMobileNumberController.submit) {
 
-        <div class="form-group">
         @text(
             field = mobileNumberForm("mobileNumber"),
             pageTitle = messages("captureMobile.title"),
             additionalContent = Some(formHint)
         )
-        </div>
 
         @if(currentMobile != "") {
             <p><a id="remove-mobile" href='@controllers.mobileNumber.routes.ConfirmRemoveMobileController.show().url'>

--- a/app/views/templates/errors/ErrorSummary.scala.html
+++ b/app/views/templates/errors/ErrorSummary.scala.html
@@ -14,34 +14,28 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.play.views.html.helpers.{ErrorSummary => Summary}
-
-@this(summary: Summary)
+@this()
 
 @(heading: String, form: Form[_], formId: Option[String] = None)(implicit messages: Messages)
 
 @if(form.hasErrors) {
 
-    <div class="flash error-summary@if(form.hasErrors) { error-summary--show}"
-    id="error-summary-display"
-    role="alert"
-    aria-labelledby="error-summary-heading"
-    tabindex="-1">
-        <h2 id="error-summary-heading" class="h3-heading">@messages(heading)</h2>
-        <ul class="js-error-summary-messages">
-        @form.errors.map { error =>
-
-            @defining(if(error.key == "") formId.map(x => x) else error.key) { key =>
-
-                <li role="tooltip">
-                    <a href="#@key"
-                    id="@{key}-error-summary"
-                    data-focuses="@{key}">
-                    @messages(error.message, error.args: _*)
-                    </a>
-                </li>
-            }
-        }
-        </ul>
-    </div>
+  <div class="flash error-summary@if(form.hasErrors) { error-summary--show}"
+       id="error-summary-display"
+       role="alert"
+       aria-labelledby="error-summary-heading"
+       tabindex="-1">
+    <h2 id="error-summary-heading" class="h3-heading">@messages(heading)</h2>
+    <ul class="js-error-summary-messages">
+      @form.errors.map { error =>
+        <li class="error-summary-list">
+          <a href="#@error.key"
+             id="@{error.key}-error-summary"
+             data-focuses="@{error.key}">
+            @messages(error.message, error.args: _*)
+          </a>
+        </li>
+      }
+    </ul>
+  </div>
 }

--- a/app/views/templates/inputs/RadioGroup.scala.html
+++ b/app/views/templates/inputs/RadioGroup.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import views.html.helper._
+@import forms.YesNoForm.yesNo
 
 @this()
 
@@ -24,28 +24,34 @@
   additionalContent: Option[Html] = None,
   inline: Boolean = false)(implicit messages: Messages)
 
-@elements = @{ FieldElements(field.id, field, null, Map(), messages) }
+<div id="@yesNo" class="form-group">
 
-<div @if(elements.hasErrors){ class="form-field--error"}>
+  <fieldset aria-describedby="form-hint@if(field.hasErrors){ form-error}">
 
-    <fieldset>
+    <div class="form-field@if(field.hasErrors){--error panel-border-narrow}">
+
         <legend>
             <h1 id="page-heading" class="heading-large">@question</h1>
         </legend>
 
         @additionalContent.map { content => @content }
 
-        @elements.errors.map { error => <span class="error-message">@messages(error)</span> }
+        @field.errors.headOption.map { error =>
+          <span id="form-error" class="error-message">
+            <span class="visuallyhidden">@messages("common.error")</span>
+            @messages(error.message)
+          </span>
+        }
 
         <div @if(inline){ class="inline"}>
             @choices.map { case (value, label) =>
 
-                @defining(s"${elements.field.name}-${value.toLowerCase}") { inputId =>
+                @defining(s"${field.name}-${value.toLowerCase}") { inputId =>
                     <div class="multiple-choice">
                         <input
                             type="radio"
                             id="@inputId"
-                            name="@elements.field.name"
+                            name="@field.name"
                             value="@value"
                             @field.value.filter( _ == value).map{_ => checked="checked"}/>
                         <label for="@inputId">@label</label>
@@ -53,5 +59,6 @@
                 }
             }
         </div>
-    </fieldset>
+    </div>
+  </fieldset>
 </div>

--- a/app/views/templates/inputs/Text.scala.html
+++ b/app/views/templates/inputs/Text.scala.html
@@ -20,20 +20,28 @@
   pageTitle: String,
   additionalContent: Option[Html] = None)(implicit messages: Messages)
 
-<div class="form-field@if(field.hasErrors){--error panel-border-narrow}">
+<div class="form-group">
 
-  <h1 id="page-heading"><label for="@field.id" class="heading-large">@messages(pageTitle)</label></h1>
+  <fieldset aria-describedby="form-hint@if(field.hasErrors){ form-error}">
 
-  @additionalContent.map { content => @content }
+    <div class="form-field@if(field.hasErrors){--error panel-border-narrow}">
 
-  @field.errors.headOption.map { error =>
-    <span class="error-message" role="tooltip">
-      @messages(error.message, error.args: _*)
-    </span>
-  }
+      <h1 id="page-heading"><label for="@field.id" class="heading-large">@messages(pageTitle)</label></h1>
 
-  <input class="form-control input--no-spinner"
-         name="@field.name"
-         id="@field.name"
-         value="@field.value.getOrElse("")"/>
+      @additionalContent.map { content => @content }
+
+      @field.errors.headOption.map { error =>
+        <span id="form-error" class="error-message">
+          <span class="visuallyhidden">@messages("common.error")</span>
+          @messages(error.message, error.args: _*)
+        </span>
+      }
+
+      <input class="form-control input--no-spinner"
+             name="@field.name"
+             id="@field.name"
+             value="@field.value.getOrElse("")"/>
+
+    </div>
+  </fieldset>
 </div>

--- a/app/views/website/CaptureWebsiteView.scala.html
+++ b/app/views/website/CaptureWebsiteView.scala.html
@@ -24,7 +24,7 @@
 @(websiteForm: Form[String], currentWebsite: String)(implicit user: User[_], messages: Messages, appConfig: AppConfig)
 
 @formHint = {
-  <span class="form-hint">@messages("captureWebsite.hint")</span>
+  <span id="form-hint" class="form-hint">@messages("captureWebsite.hint")</span>
 }
 
 @mainTemplate(if(websiteForm.errors.nonEmpty) messages("common.error.prefixTitle", messages("captureWebsite.title")) else messages("captureWebsite.title")) {
@@ -34,13 +34,11 @@
     @errorSummary(messages("common.error.heading"), websiteForm)
 
     @form(action = controllers.website.routes.CaptureWebsiteController.submit, 'novalidate -> "novalidate") {
-        <div class="form-group">
         @text(
             field = websiteForm("website"),
             pageTitle = messages("captureWebsite.title"),
             additionalContent = Some(formHint)
         )
-        </div>
 
         @if(currentWebsite != ""){
           <p><a id="remove-website" href='@controllers.website.routes.ConfirmRemoveWebsiteController.show().url'>

--- a/conf/messages
+++ b/conf/messages
@@ -14,6 +14,7 @@ common.clientService = Business tax account
 common.agentService = Your client’s VAT details
 common.vat = VAT
 common.continue = Continue
+common.error = Error:
 common.error.heading = There is a problem
 common.error.prefixTitle = Error: {0}
 common.whatHappensNext = What happens next

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -14,6 +14,7 @@ common.clientService = Cyfrif Treth Busnes
 common.agentService = Manylion TAW eich cleient
 common.vat = TAW
 common.continue = Yn eich blaen
+common.error = Gwall:
 common.error.heading = Mae problem wedi codi
 common.error.prefixTitle = Gwall: {0}
 common.whatHappensNext = Yr hyn sy’n digwydd nesaf

--- a/it/pages/contactPreference/EmailPreferencePageSpec.scala
+++ b/it/pages/contactPreference/EmailPreferencePageSpec.scala
@@ -201,7 +201,7 @@ class EmailPreferencePageSpec extends BasePageISpec {
           res should have(
             httpStatus(Status.BAD_REQUEST),
             pageTitle("Error: " + generateDocumentTitle("emailPreference.title")),
-            elementText(".error-message")("Select yes if you want communications by email")
+            elementText(".error-message")("Error: Select yes if you want communications by email")
           )
         }
       }

--- a/it/pages/contactPreference/EmailToUsePageSpec.scala
+++ b/it/pages/contactPreference/EmailToUsePageSpec.scala
@@ -194,7 +194,7 @@ class EmailToUsePageSpec extends BasePageISpec {
           res should have(
             httpStatus(Status.BAD_REQUEST),
             pageTitle("Error: " + generateDocumentTitle("emailToUse.title")),
-            elementText(".error-message")("Select yes if this is the email address you want us to use")
+            elementText(".error-message")("Error: Select yes if this is the email address you want us to use")
           )
         }
       }

--- a/it/pages/contactPreference/LetterPreferencePageSpec.scala
+++ b/it/pages/contactPreference/LetterPreferencePageSpec.scala
@@ -146,7 +146,7 @@ class LetterPreferencePageSpec extends BasePageISpec {
           res should have(
             httpStatus(Status.BAD_REQUEST),
             pageTitle("Error: " + generateDocumentTitle("letterPreference.title")),
-            elementText(".error-message")("Select yes if you want communications by letter")
+            elementText(".error-message")("Error: Select yes if you want communications by letter")
           )
         }
       }

--- a/test/views/contactPreference/AddEmailAddressViewSpec.scala
+++ b/test/views/contactPreference/AddEmailAddressViewSpec.scala
@@ -32,8 +32,9 @@ class AddEmailAddressViewSpec extends ViewBaseSpec {
     val backLink = "#content > article > a"
     val form = "form"
     val button = ".button"
-    val line1 = "#yes_no > div:nth-child(1) > fieldset:nth-child(1) > div:nth-child(2) > p:nth-child(1)"
-    val line2 = "#yes_no > div:nth-child(1) > fieldset:nth-child(1) > div:nth-child(2) > p:nth-child(2)"
+    val line1 = ".form-field > div:nth-child(2) > p:nth-child(1)"
+    val line2 = ".form-field > div:nth-child(2) > p:nth-child(2)"
+    val question = ".form-field > div:nth-child(2) > p:nth-child(3)"
     val yesOption = "div.multiple-choice:nth-child(1) > label"
     val noOption = "div.multiple-choice:nth-child(2) > label"
     val errorHeading = "#error-summary-display"
@@ -56,6 +57,10 @@ class AddEmailAddressViewSpec extends ViewBaseSpec {
     "have the correct paragraph content" in {
       elementText(Selectors.line1) shouldBe ContactPrefAddEmailMessages.info1
       elementText(Selectors.line2) shouldBe ContactPrefAddEmailMessages.info2
+    }
+
+    "have the correct question" in {
+      elementText(Selectors.question) shouldBe ContactPrefAddEmailMessages.question
     }
 
     "have a back link" which {
@@ -105,7 +110,7 @@ class AddEmailAddressViewSpec extends ViewBaseSpec {
     }
 
     "display the correct error message" in {
-      elementText(Selectors.error) shouldBe ContactPrefAddEmailMessages.errorMessage
+      elementText(Selectors.error) shouldBe s"${ContactPrefAddEmailMessages.errorTitlePrefix} ${ContactPrefAddEmailMessages.errorMessage}"
     }
   }
 }

--- a/test/views/contactPreference/EmailPreferenceViewSpec.scala
+++ b/test/views/contactPreference/EmailPreferenceViewSpec.scala
@@ -103,7 +103,7 @@ class EmailPreferenceViewSpec extends ViewBaseSpec {
     }
 
     "display the correct error message" in {
-      elementText(Selectors.error) shouldBe EmailPrefMessages.errorMessage
+      elementText(Selectors.error) shouldBe s"${EmailPrefMessages.errorTitlePrefix} ${EmailPrefMessages.errorMessage}"
     }
   }
 }

--- a/test/views/contactPreference/EmailToUseViewSpec.scala
+++ b/test/views/contactPreference/EmailToUseViewSpec.scala
@@ -110,7 +110,7 @@ class EmailToUseViewSpec extends ViewBaseSpec {
     }
 
     "display the correct error message" in {
-      elementText(Selectors.error) shouldBe viewMessages.errorMessage
+      elementText(Selectors.error) shouldBe s"${viewMessages.errorTitlePrefix} ${viewMessages.errorMessage}"
     }
   }
 

--- a/test/views/contactPreference/LetterPreferenceViewSpec.scala
+++ b/test/views/contactPreference/LetterPreferenceViewSpec.scala
@@ -122,7 +122,7 @@ class LetterPreferenceViewSpec extends ViewBaseSpec {
     }
 
     "display the correct error message" in {
-      elementText(Selectors.error) shouldBe LetterPreferenceMessages.errorMessage
+      elementText(Selectors.error) shouldBe s"${LetterPreferenceMessages.errorTitlePrefix} ${LetterPreferenceMessages.errorMessage}"
     }
 
   }

--- a/test/views/email/CaptureEmailViewSpec.scala
+++ b/test/views/email/CaptureEmailViewSpec.scala
@@ -39,7 +39,7 @@ class CaptureEmailViewSpec extends ViewBaseSpec {
     val removeEmailDesc = ".panel-border-narrow"
     val removeEmailLink = ".panel-border-narrow a"
     val onlyAddEmail = ".form-field > p:nth-child(2)"
-    val fieldLabel: String = "#content > article > form > div > div > span.form-hint"
+    val fieldLabel: String = ".form-hint"
     val hmrcPrivacyNotice: String = "#hmrc-privacy-notice"
     val hmrcPrivacyNoticeLink: String = "#hmrc-privacy-notice > a"
   }
@@ -160,7 +160,7 @@ class CaptureEmailViewSpec extends ViewBaseSpec {
         }
 
         "have the correct error notification text above the input box" in {
-          elementText(".error-message") shouldBe "Enter a different email address"
+          elementText(".error-message") shouldBe "Error: Enter a different email address"
         }
 
         "display the error summary" in {

--- a/test/views/landlineNumber/CaptureLandlineNumberViewSpec.scala
+++ b/test/views/landlineNumber/CaptureLandlineNumberViewSpec.scala
@@ -106,7 +106,7 @@ class CaptureLandlineNumberViewSpec extends ViewBaseSpec {
         }
 
         "have the correct error notification text above the input box" in {
-          elementText(".error-message") shouldBe "You have not made any changes to the landline number"
+          elementText(".error-message") shouldBe "Error: You have not made any changes to the landline number"
         }
 
         "display the error summary" in {

--- a/test/views/mobileNumber/CaptureMobileNumberViewSpec.scala
+++ b/test/views/mobileNumber/CaptureMobileNumberViewSpec.scala
@@ -105,7 +105,7 @@ class CaptureMobileNumberViewSpec extends ViewBaseSpec {
         }
 
         "have the correct error notification text above the input box" in {
-          elementText(".error-message") shouldBe "You have not made any changes to the mobile number"
+          elementText(".error-message") shouldBe "Error: You have not made any changes to the mobile number"
         }
 
         "display the error summary" in {

--- a/test/views/templates/errors/ErrorSummarySpec.scala
+++ b/test/views/templates/errors/ErrorSummarySpec.scala
@@ -38,7 +38,7 @@ class ErrorSummarySpec extends ViewBaseSpec {
              |<div class="flash error-summary error-summary--show" id="error-summary-display" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
              |  <h2 id="error-summary-heading" class="h3-heading">heading</h2>
              |  <ul class="js-error-summary-messages">
-             |    <li role="tooltip"> <a href="#email" id="email-error-summary" data-focuses="email"> Enter a different email address </a> </li>
+             |    <li class="error-summary-list"> <a href="#email" id="email-error-summary" data-focuses="email"> Enter a different email address </a> </li>
              |  </ul>
              |</div>
            """.stripMargin

--- a/test/views/templates/inputs/RadioGroupTemplateSpec.scala
+++ b/test/views/templates/inputs/RadioGroupTemplateSpec.scala
@@ -52,8 +52,9 @@ class RadioGroupTemplateSpec extends ViewBaseSpec {
       val field: Field = Field(YesNoForm.yesNoForm(errorMessage), fieldName, Seq(), None, Seq(), None)
       val expectedMarkup = Html(
         s"""
-           |  <div>
-           |    <fieldset>
+           |<div id="yes_no" class="form-group">
+           |  <fieldset aria-describedby="form-hint">
+           |    <div class="form-field">
            |      <legend>
            |        <h1 id="page-heading" class="heading-large">$labelText</h1>
            |      </legend>
@@ -65,9 +66,9 @@ class RadioGroupTemplateSpec extends ViewBaseSpec {
            |        ${generateExpectedRadioMarkup("value4", "display4")}
            |        ${generateExpectedRadioMarkup("value5", "display5")}
            |      </div>
-           |
-           |   </fieldset>
-           |  </div>
+           |    </div>
+           |  </fieldset>
+           |</div>
         """.stripMargin
       )
 
@@ -82,8 +83,9 @@ class RadioGroupTemplateSpec extends ViewBaseSpec {
       val field: Field = Field(YesNoForm.yesNoForm(errorMessage), fieldName, Seq(), None, Seq(), Some("value2"))
       val expectedMarkup = Html(
         s"""
-           |  <div>
-           |     <fieldset>
+           |<div id="yes_no" class="form-group">
+           |  <fieldset aria-describedby="form-hint">
+           |    <div class="form-field">
            |      <legend>
            |        <h1 id="page-heading" class="heading-large">$labelText</h1>
            |      </legend>
@@ -95,8 +97,9 @@ class RadioGroupTemplateSpec extends ViewBaseSpec {
            |        ${generateExpectedRadioMarkup("value4", "display4")}
            |        ${generateExpectedRadioMarkup("value5", "display5")}
            |      </div>
-           |    </fieldset>
-           |  </div>
+           |    </div>
+           |  </fieldset>
+           |</div>
         """.stripMargin
       )
 
@@ -111,13 +114,17 @@ class RadioGroupTemplateSpec extends ViewBaseSpec {
       val field: Field = Field(YesNoForm.yesNoForm(errorMessage), fieldName, Seq(), None, Seq(FormError("text", errorMessage)), None)
       val expectedMarkup = Html(
         s"""
-           |  <div class="form-field--error">
-           |    <fieldset>
+           |<div id="yes_no" class="form-group">
+           |  <fieldset aria-describedby="form-hint form-error">
+           |    <div class="form-field--error panel-border-narrow">
            |      <legend>
            |        <h1 id="page-heading" class="heading-large">$labelText</h1>
            |      </legend>
            |
-           |      <span class="error-message">$errorMessage</span>
+           |      <span id="form-error" class="error-message">
+           |        <span class="visuallyhidden">Error:</span>
+           |        $errorMessage
+           |      </span>
            |
            |      <div>
            |        ${generateExpectedRadioMarkup("value1", "display1")}
@@ -126,8 +133,9 @@ class RadioGroupTemplateSpec extends ViewBaseSpec {
            |        ${generateExpectedRadioMarkup("value4", "display4")}
            |        ${generateExpectedRadioMarkup("value5", "display5")}
            |      </div>
-           |    </fieldset>
-           |  </div>
+           |    </div>
+           |  </fieldset>
+           |</div>
         """.stripMargin
       )
 
@@ -143,8 +151,9 @@ class RadioGroupTemplateSpec extends ViewBaseSpec {
       val field: Field = Field(YesNoForm.yesNoForm(errorMessage), fieldName, Seq(), None, Seq(), None)
       val expectedMarkup = Html(
         s"""
-           |<div>
-           |    <fieldset>
+           |<div id="yes_no" class="form-group">
+           |  <fieldset aria-describedby="form-hint">
+           |    <div class="form-field">
            |      <legend>
            |        <h1 id="page-heading" class="heading-large">$labelText</h1>
            |      </legend>
@@ -158,8 +167,8 @@ class RadioGroupTemplateSpec extends ViewBaseSpec {
            |        ${generateExpectedRadioMarkup("value4", "display4")}
            |        ${generateExpectedRadioMarkup("value5", "display5")}
            |      </div>
-           |
-           |    </fieldset>
+           |    </div>
+           |  </fieldset>
            |</div>
         """.stripMargin
       )

--- a/test/views/templates/inputs/TextHelperSpec.scala
+++ b/test/views/templates/inputs/TextHelperSpec.scala
@@ -38,9 +38,13 @@ class TextHelperSpec extends ViewBaseSpec {
 
         val expectedMarkup = Html(
           s"""
-             |<div class="form-field">
-             |  <h1 id="page-heading"><label for="$fieldName" class="heading-large">$title</label></h1>
-             |  <input class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value="text">
+             |<div class="form-group">
+             |  <fieldset aria-describedby="form-hint">
+             |    <div class="form-field">
+             |      <h1 id="page-heading"><label for="$fieldName" class="heading-large">$title</label></h1>
+             |      <input class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value="text">
+             |    </div>
+             |  </fieldset>
              |</div>
              |""".stripMargin
         )
@@ -59,12 +63,17 @@ class TextHelperSpec extends ViewBaseSpec {
 
         val expectedMarkup = Html(
           s"""
-             |<div class="form-field--error panel-border-narrow">
-             |  <h1 id="page-heading"><label for="$fieldName" class="heading-large">$title</label></h1>
-             |  <span class="error-message" role="tooltip">
-             |    ERROR
-             |  </span>
-             |  <input class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value="text">
+             |<div class="form-group">
+             |  <fieldset aria-describedby="form-hint form-error">
+             |    <div class="form-field--error panel-border-narrow">
+             |      <h1 id="page-heading"><label for="$fieldName" class="heading-large">$title</label></h1>
+             |      <span id="form-error" class="error-message">
+             |        <span class="visuallyhidden">Error:</span>
+             |        ERROR
+             |      </span>
+             |      <input class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value="text">
+             |    </div>
+             |  </fieldset>
              |</div>
              |""".stripMargin
         )
@@ -81,10 +90,14 @@ class TextHelperSpec extends ViewBaseSpec {
 
         val expectedMarkup = Html(
           s"""
-             |<div class="form-field">
-             |  <h1 id="page-heading"><label for="$fieldName" class="heading-large">$title</label></h1>
-             |  <p>Additional HTML</p>
-             |  <input class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value="text">
+             |<div class="form-group">
+             |  <fieldset aria-describedby="form-hint">
+             |    <div class="form-field">
+             |      <h1 id="page-heading"><label for="$fieldName" class="heading-large">$title</label></h1>
+             |      <p>Additional HTML</p>
+             |      <input class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value="text">
+             |    </div>
+             |  </fieldset>
              |</div>
              |""".stripMargin
         )

--- a/test/views/website/CaptureWebsiteViewSpec.scala
+++ b/test/views/website/CaptureWebsiteViewSpec.scala
@@ -127,7 +127,7 @@ class CaptureWebsiteViewSpec extends ViewBaseSpec {
         }
 
         "have the correct error notification text above the input box" in {
-          elementText(".error-message") shouldBe "Enter a new website address"
+          elementText(".error-message") shouldBe "Error: Enter a new website address"
         }
 
         "display the error summary" in {


### PR DESCRIPTION
This work addresses the following two issues raised by the a11y pre-audit:
- Error summary does not follow pattern styles
- Hints / errot hint do not follow pattern (A)

The following work applies the following fixes:
- Removes invalid `role="tooltip"` from components
- Sets the error summary text to the correct red colour and makes the text bold
- Adds a `fieldset` to form components to make use of the `aria-describedby` attribute to link to form hints and error messages
- Prefixes every error message with visually hidden content "Error: "