### PR TITLE
Removed warn logging for expected scenario

### DIFF
--- a/app/controllers/email/VerifyEmailController.scala
+++ b/app/controllers/email/VerifyEmailController.scala
@@ -65,7 +65,7 @@ class VerifyEmailController @Inject()(val emailVerificationService: EmailVerific
         emailVerificationService.createEmailVerificationRequest(email, routes.ConfirmEmailController.updateEmailAddress().url).map{
           case Some(true) => Redirect(routes.VerifyEmailController.emailShow())
           case Some(false) =>
-            logWarn(
+            logDebug(
               "[VerifyEmailController][sendVerification] - " +
                 "Unable to send email verification request. Service responded with 'already verified'"
             )


### PR DESCRIPTION
We're currently getting a lot of logs for this, which looks to be a valid and expected scenario. One example of how this could be triggered is if a user verifies their email in a separate tab to the one they got to the verify page in, then presses a link (such as "send it again") in the first tab.