### PR TITLE
BTAT-8417 Added verify email address passcode view

### DIFF
--- a/app/views/email/CaptureEmailView.scala.html
+++ b/app/views/email/CaptureEmailView.scala.html
@@ -49,7 +49,7 @@
         @form(action = submitFormAction) {
             @text(
                 field = emailForm("email"),
-                pageTitle = messages("captureEmail.title"),
+                pageTitle = Some(messages("captureEmail.title")),
                 additionalContent = Some(additionalContent)
             )
 

--- a/app/views/email/PasscodeView.scala.html
+++ b/app/views/email/PasscodeView.scala.html
@@ -1,0 +1,87 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.AppConfig
+@import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+@import views.html.templates.errors.ErrorSummary
+@import views.html.templates.inputs.Text
+
+@this(mainTemplate: MainTemplate, text: Text, form: FormWithCSRF, errorSummary: ErrorSummary)
+
+@(email: String, passcodeForm: Form[String], contactPrefJourney: Boolean)(implicit request: User[_], messages: Messages, appConfig: AppConfig)
+
+@additionalContent = {
+  <h2 class="heading-small">@messages("passcode.confirmationCode")</h2>
+  <span id="form-hint" class="form-hint">@messages("passcode.formHint")</span>
+}
+
+@startJourneyUrl = @{
+  if(contactPrefJourney) {
+    controllers.email.routes.CaptureEmailController.showPrefJourney().url
+  } else {
+    controllers.email.routes.CaptureEmailController.show().url
+  }
+}
+
+@resendVerificationUrl = @{
+  if(contactPrefJourney) {
+    "#" //TODO - new controller action
+  } else {
+    "#" //TODO - new controller action
+  }
+}
+
+@mainTemplate(
+  title = if(passcodeForm.hasErrors) messages("common.error.prefixTitle", messages("passcode.title")) else messages("passcode.title")
+){
+
+  <a class="link-back" href=@startJourneyUrl>@messages("base.back")</a>
+
+  @errorSummary(messages("common.error.heading"), passcodeForm)
+
+  <h1 id="page-heading"><label for="@passcodeForm("passcode").id" class="heading-large">
+    @messages("passcode.title")
+  </label></h1>
+
+  <p>@messages("passcode.weHaveSent")
+    <span class="bold">@email</span>
+  </p>
+  <p class="panel panel-border-wide">@messages("passcode.newTabOrWindow")</p>
+
+  @form(action = Call("GET", "/test")) { <!-- TODO - new controller action -->
+    @text(
+      field = passcodeForm("passcode"),
+      pageTitle = None,
+      additionalContent = Some(additionalContent)
+    )
+  }
+
+  <details class="controlpanel">
+    <summary><span class="summary">@messages("passcode.notReceived")</span></summary>
+    <div class="panel panel-border-narrow">
+      <p>@messages("passcode.subjectLine")</p>
+      <p>@messages("passcode.stillNotArrived.1")
+        <a href=@resendVerificationUrl>@messages("passcode.stillNotArrived.2")</a>
+        @messages("passcode.stillNotArrived.3")
+        <a href=@startJourneyUrl>@messages("passcode.stillNotArrived.4")</a>@messages("common.fullstop")
+      </p>
+    </div>
+  </details>
+
+  <div class="form-group">
+    <button class="button" type="submit">@messages("common.continue")</button>
+  </div>
+}

--- a/app/views/landlineNumber/CaptureLandlineNumberView.scala.html
+++ b/app/views/landlineNumber/CaptureLandlineNumberView.scala.html
@@ -39,7 +39,7 @@
     @form(action = controllers.landlineNumber.routes.CaptureLandlineNumberController.submit) {
         @text(
             field = landlineForm("landlineNumber"),
-            pageTitle = messages("captureLandline.title"),
+            pageTitle = Some(messages("captureLandline.title")),
             additionalContent = Some(formHint)
         )
 

--- a/app/views/mobileNumber/CaptureMobileNumberView.scala.html
+++ b/app/views/mobileNumber/CaptureMobileNumberView.scala.html
@@ -40,7 +40,7 @@
 
         @text(
             field = mobileNumberForm("mobileNumber"),
-            pageTitle = messages("captureMobile.title"),
+            pageTitle = Some(messages("captureMobile.title")),
             additionalContent = Some(formHint)
         )
 

--- a/app/views/templates/inputs/Text.scala.html
+++ b/app/views/templates/inputs/Text.scala.html
@@ -17,7 +17,7 @@
 @this()
 
 @(field: Field,
-  pageTitle: String,
+  pageTitle: Option[String],
   additionalContent: Option[Html] = None)(implicit messages: Messages)
 
 <div class="form-group">
@@ -26,7 +26,9 @@
 
     <div class="form-field@if(field.hasErrors){--error panel-border-narrow}">
 
-      <h1 id="page-heading"><label for="@field.id" class="heading-large">@messages(pageTitle)</label></h1>
+      @pageTitle.map { title =>
+        <h1 id="page-heading"><label for="@field.id" class="heading-large">@messages(title)</label></h1>
+      }
 
       @additionalContent.map { content => @content }
 

--- a/app/views/website/CaptureWebsiteView.scala.html
+++ b/app/views/website/CaptureWebsiteView.scala.html
@@ -36,7 +36,7 @@
     @form(action = controllers.website.routes.CaptureWebsiteController.submit, 'novalidate -> "novalidate") {
         @text(
             field = websiteForm("website"),
-            pageTitle = messages("captureWebsite.title"),
+            pageTitle = Some(messages("captureWebsite.title")),
             additionalContent = Some(formHint)
         )
 

--- a/conf/messages
+++ b/conf/messages
@@ -167,3 +167,15 @@ cPrefAddEmail.error = Select yes if you want to add an email address
 contactPrefConfirmation.title = You have asked us to change how we contact you about VAT
 contactPrefConfirmation.contactYou = If we can accept the change, we will contact you about VAT at:
 contactPrefConfirmation.stillNeedLetters = We’ll still need to send you some letters in the post because the law tells us to.
+
+passcode.title = Enter code to confirm your email address
+passcode.weHaveSent = We have sent a code to:
+passcode.newTabOrWindow = Open a new tab or window if you need to access your emails online.
+passcode.confirmationCode = Confirmation code
+passcode.formHint = For example, DNCLRK
+passcode.notReceived = I have not received the email
+passcode.subjectLine = The email might take a few minutes to arrive. Its subject line is: ‘Confirm your email address - VAT account’.
+passcode.stillNotArrived.1 = Check your spam or junk folder. If the email has still not arrived, you can
+passcode.stillNotArrived.2 = request a new code
+passcode.stillNotArrived.3 = or
+passcode.stillNotArrived.4 = provide another email address

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -164,3 +164,15 @@ cPrefAddEmail.error = Dewiswch ‘Iawn’ os ydych am ychwanegu cyfeiriad e-bost
 contactPrefConfirmation.title = Rydych wedi gofyn i ni newid sut yr ydym yn cysylltu â chi ynghylch TAW
 contactPrefConfirmation.contactYou = Os gallwn dderbyn y newid, byddwn yn cysylltu â chi ynghylch TAW yn:
 contactPrefConfirmation.stillNeedLetters = Bydd angen i ni anfon rhai llythyrau atoch drwy’r post o hyd oherwydd bod y gyfraith yn dweud wrthym am wneud hynny.
+
+passcode.title = Nodwch y cod i gadarnhau eich cyfeiriad e-bost
+passcode.weHaveSent = Rydym wedi anfon cod i:
+passcode.newTabOrWindow = Agorwch dab neu ffenestr newydd os oes angen i chi gael mynediad at eich e-byst ar-lein.
+passcode.confirmationCode = Cod cadarnhau
+passcode.formHint = Er enghraifft, DNCLRK
+passcode.notReceived = Nid wyf wedi cael yr e-bost
+passcode.subjectLine = Gall yr e-bost gymryd ychydig o funudau i gyrraedd. Llinell pwnc yr e-bost yw: ‘Cadarnhau’ch cyfeiriad e-bost - cyfrif TAW’ / ‘Confirm your email address - VAT account’.
+passcode.stillNotArrived.1 = Gwiriwch eich ffolder sbam neu sothach. Os nad yw’r e-bost wedi cyrraedd o hyd, gallwch
+passcode.stillNotArrived.2 = ofyn am god newydd
+passcode.stillNotArrived.3 = neu
+passcode.stillNotArrived.4 = roi cyfeiriad e-bost arall

--- a/test/views/email/PasscodeViewSpec.scala
+++ b/test/views/email/PasscodeViewSpec.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.email
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.data.{Form, FormError}
+import play.api.data.Forms.nonEmptyText
+import play.twirl.api.Html
+import views.ViewBaseSpec
+import views.html.email.PasscodeView
+
+class PasscodeViewSpec extends ViewBaseSpec {
+
+  val injectedView: PasscodeView = inject[PasscodeView]
+  val testForm: Form[String] = Form("passcode" -> nonEmptyText) //TODO - replace with real form
+
+  "The passcode view in the change of email journey" should {
+
+    lazy val view: Html = injectedView(testEmail, testForm, contactPrefJourney = false)(user, messages, mockConfig)
+    lazy implicit val document: Document = Jsoup.parse(view.body)
+
+    "have the correct document title" in {
+      document.title shouldBe "Enter code to confirm your email address - Business tax account - GOV.UK"
+    }
+
+    "have the correct heading" in {
+      elementText("h1") shouldBe "Enter code to confirm your email address"
+    }
+
+    "have a back link" which {
+
+      "has the correct text" in {
+        elementText(".link-back") shouldBe "Back"
+      }
+
+      "has the correct destination" in {
+        element(".link-back").attr("href") shouldBe controllers.email.routes.CaptureEmailController.show().url
+      }
+    }
+
+    "have the correct first paragraph" in {
+      elementText("#content article p:nth-of-type(1)") shouldBe s"We have sent a code to: $testEmail"
+    }
+
+    "have the correct panel paragraph" in {
+      elementText("p.panel") shouldBe "Open a new tab or window if you need to access your emails online."
+    }
+
+    "have the correct subheading for the form" in {
+      elementText("h2") shouldBe "Confirmation code"
+    }
+
+    "have the correct form hint" in {
+      elementText("#form-hint") shouldBe "For example, DNCLRK"
+    }
+
+    "have the correct progressive disclosure text" in {
+      elementText(".summary") shouldBe "I have not received the email"
+    }
+
+    "have the correct first paragraph inside of the progressive disclosure" in {
+      elementText("details div p:nth-child(1)") shouldBe
+        "The email might take a few minutes to arrive. Its subject line is: ‘Confirm your email address - VAT account’."
+    }
+
+    "have the correct second paragraph inside of the progressive disclosure" in {
+      elementText("details div p:nth-child(2)") shouldBe "Check your spam or junk folder. " +
+        "If the email has still not arrived, you can request a new code or provide another email address."
+    }
+
+    "have a link to resend the passcode" which {
+
+      "has the correct text" in {
+        elementText("details div p:nth-child(2) a:nth-child(1)") shouldBe "request a new code"
+      }
+
+      "has the correct destination" in {
+        element("details div p:nth-child(2) a:nth-child(1)").attr("href") shouldBe "#"
+      }
+    }
+
+    "have a link to enter a new email address" which {
+
+      "has the correct text" in {
+        elementText("details div p:nth-child(2) a:nth-child(2)") shouldBe "provide another email address"
+      }
+
+      "has the correct destination" in {
+        element("details div p:nth-child(2) a:nth-child(2)").attr("href") shouldBe
+          controllers.email.routes.CaptureEmailController.show().url
+      }
+    }
+
+    "have a button with the correct text" in {
+      elementText(".button") shouldBe "Continue"
+    }
+  }
+
+  "The passcode view in the change of contact preference journey" should {
+
+    lazy val view: Html = injectedView(testEmail, testForm, contactPrefJourney = true)(user, messages, mockConfig)
+    lazy implicit val document: Document = Jsoup.parse(view.body)
+
+    "have a back link" which {
+
+      "has the correct destination" in {
+        element(".link-back").attr("href") shouldBe controllers.email.routes.CaptureEmailController.showPrefJourney().url
+      }
+    }
+
+    "have a link to resend the passcode" which {
+
+      "has the correct destination" in {
+        element("details div p:nth-child(2) a:nth-child(1)").attr("href") shouldBe "#"
+      }
+    }
+
+    "have a link to enter a new email address" which {
+
+      "has the correct destination" in {
+        element("details div p:nth-child(2) a:nth-child(2)").attr("href") shouldBe
+          controllers.email.routes.CaptureEmailController.showPrefJourney().url
+      }
+    }
+  }
+
+  "The passcode view when there are errors in the form" should {
+
+    val errorForm = testForm.withError(FormError("passcode", "Test error")) //TODO - replace with real form
+    lazy val view: Html = injectedView(testEmail, errorForm, contactPrefJourney = true)(user, messages, mockConfig)
+    lazy implicit val document: Document = Jsoup.parse(view.body)
+
+    "have the correct document title" in {
+      document.title shouldBe "Error: Enter code to confirm your email address - Business tax account - GOV.UK"
+    }
+
+    "have an error summary" which {
+
+      "has the correct heading" in {
+        elementText("#error-summary-heading") shouldBe "There is a problem"
+      }
+
+      "has the correct error message" in {
+        elementText("#passcode-error-summary") shouldBe "Test error"
+      }
+
+      "has a link to the input with the error" in {
+        element("#passcode-error-summary").attr("href") shouldBe "#passcode"
+      }
+    }
+
+    "have the correct error notification text above the input box" in {
+      elementText(".error-message") shouldBe "Error: Test error"
+    }
+  }
+}

--- a/test/views/templates/inputs/TextHelperSpec.scala
+++ b/test/views/templates/inputs/TextHelperSpec.scala
@@ -49,7 +49,7 @@ class TextHelperSpec extends ViewBaseSpec {
              |""".stripMargin
         )
 
-        val result = injectedView(field, title)
+        val result = injectedView(field, Some(title))
 
         formatHtml(result) shouldBe formatHtml(expectedMarkup)
       }
@@ -78,7 +78,7 @@ class TextHelperSpec extends ViewBaseSpec {
              |""".stripMargin
         )
 
-        val result = injectedView(errorField, title)
+        val result = injectedView(errorField, Some(title))
 
         formatHtml(result) shouldBe formatHtml(expectedMarkup)
       }
@@ -102,7 +102,29 @@ class TextHelperSpec extends ViewBaseSpec {
              |""".stripMargin
         )
 
-        val result = injectedView(field, title, additionalContent = Some(Html("<p>Additional HTML</p>")))
+        val result = injectedView(field, Some(title), additionalContent = Some(Html("<p>Additional HTML</p>")))
+
+        formatHtml(result) shouldBe formatHtml(expectedMarkup)
+      }
+    }
+
+    "there is no page title" should {
+
+      "render the provided content inside of the form" in {
+
+        val expectedMarkup = Html(
+          s"""
+             |<div class="form-group">
+             |  <fieldset aria-describedby="form-hint">
+             |    <div class="form-field">
+             |      <input class="form-control input--no-spinner" name="$fieldName" id="$fieldName" value="text">
+             |    </div>
+             |  </fieldset>
+             |</div>
+             |""".stripMargin
+        )
+
+        val result = injectedView(field, None)
 
         formatHtml(result) shouldBe formatHtml(expectedMarkup)
       }


### PR DESCRIPTION
As part of this I have also had to extend the `Text` helper so that the page title is optional, due to the way the form error needs to render on this page.