### PR TITLE
[BTAT-10283] Create controller for bounced email page

### DIFF
--- a/app/controllers/email/BouncedEmailController.scala
+++ b/app/controllers/email/BouncedEmailController.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.email
+
+import com.google.inject.Inject
+import common.SessionKeys
+import config.{AppConfig, ErrorHandler}
+import controllers.BaseController
+import controllers.predicates.AuthPredicateComponents
+import controllers.predicates.inflight.InFlightPredicateComponents
+import forms.YesNoForm.yesNoForm
+import models.{No, User, Yes}
+import play.api.mvc.{Action, AnyContent}
+import services.VatSubscriptionService
+import utils.LoggerUtil
+
+import scala.concurrent.ExecutionContext
+
+class BouncedEmailController @Inject()(val errorHandler: ErrorHandler,
+                                       val subscriptionService: VatSubscriptionService)
+                                      (implicit val authComps: AuthPredicateComponents,
+                                       inFlightComps: InFlightPredicateComponents,
+                                       appConfig: AppConfig) extends BaseController with LoggerUtil {
+
+  implicit val ec: ExecutionContext = authComps.mcc.executionContext
+
+  def show: Action[AnyContent] = blockAgentPredicate.async { implicit user =>
+    subscriptionService.getCustomerInfo(user.vrn) map {
+      case Right(details) => {
+        val email = details.ppob.contactDetails.flatMap(_.emailAddress)
+        val emailVerified = details.ppob.contactDetails.flatMap(_.emailVerified)
+
+        (email, emailVerified) match {
+          case (Some(_), Some(true)) => Redirect(appConfig.vatOverviewUrl)
+          case (Some(email), _) => Ok(email) //TODO: put view in here and pass in email along with form
+            .addingToSession(SessionKeys.validationEmailKey -> email)
+          case _ => Redirect(appConfig.vatOverviewUrl)
+        }
+      }
+      case _ => errorHandler.showInternalServerError
+    }
+  }
+
+  def submit: Action[AnyContent] = blockAgentPredicate { implicit user =>
+    user.session.get(SessionKeys.validationEmailKey) match {
+      case Some(email) => {
+        yesNoForm("error").bindFromRequest.fold(
+          errorForm => BadRequest(""), //TODO: put bounced email view in here and replace yesNoForm with BouncedEmailForm
+          {
+            case Yes => Redirect(routes.VerifyPasscodeController.emailSendVerification)
+              .addingToSession(SessionKeys.prepopulationEmailKey -> email)
+            case No => Redirect(routes.CaptureEmailController.show)
+          }
+        )
+      }
+      case None => errorHandler.showInternalServerError
+    }
+  }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -107,4 +107,7 @@ POST        /contact-preference/add-email-address            controllers.contact
 GET         /contact-preference-redirect                     controllers.contactPreference.ContactPreferenceRedirectController.redirect
 GET         /verify-redirect                                 controllers.email.VerifyEmailController.btaVerifyEmailRedirect
 
+GET   /fix-your-email   controllers.email.BouncedEmailController.show
+POST  /fix-your-email   controllers.email.BouncedEmailController.submit
+
 ->         /hmrc-frontend                                    hmrcfrontend.Routes

--- a/test/assets/CustomerInfoConstants.scala
+++ b/test/assets/CustomerInfoConstants.scala
@@ -171,6 +171,14 @@ object CustomerInfoConstants {
     )
   )
 
+  val customerInfoNoEmailVerifiedField: CustomerInformation = fullCustomerInfoModel.copy(
+    ppob = fullPPOBModel.copy(
+      contactDetails = Some(fullContactDetailsModel.copy(
+        emailVerified = None
+      ))
+    )
+  )
+
   val minCustomerInfoModel: CustomerInformation =
     CustomerInformation(minPPOBModel, None, None, None, None, None, None, isInsolvent = false, None, None)
 

--- a/test/controllers/email/BouncedEmailControllerSpec.scala
+++ b/test/controllers/email/BouncedEmailControllerSpec.scala
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.email
+
+import assets.CustomerInfoConstants._
+import common.SessionKeys._
+import controllers.ControllerBaseSpec
+import models.errors.ErrorModel
+import play.api.http.Status
+import play.api.http.Status._
+import play.api.test.Helpers.{defaultAwaitTimeout, redirectLocation, session, status}
+import utils.TestUtil
+
+class BouncedEmailControllerSpec extends ControllerBaseSpec with TestUtil {
+
+  object testController extends BouncedEmailController(mockErrorHandler, mockVatSubscriptionService)
+
+  "The BouncedEmailController .show method" when {
+
+    "called by a principal user" when {
+
+      "the VAT subscription call is successful" when {
+
+        "the call returns an email address that is verified" should {
+
+          lazy val result = {
+            mockIndividualAuthorised()
+            mockGetCustomerInfo(user.vrn)(Right(fullCustomerInfoModel))
+            testController.show(request)
+          }
+
+          "return 303" in {
+            status(result) shouldBe SEE_OTHER
+          }
+
+          "redirect to VAT Overview" in {
+            redirectLocation(result) shouldBe Some(mockConfig.vatOverviewUrl)
+          }
+        }
+
+        "the call returns an email address that is unverified or the emailVerified field is not returned" should {
+
+          lazy val result = {
+            mockIndividualAuthorised()
+            mockGetCustomerInfo(user.vrn)(Right(customerInfoEmailUnverified))
+            testController.show(request)
+          }
+
+          "return 200 (OK)" in {
+            status(result) shouldBe OK
+          }
+
+          "add the validation email session value" in {
+            session(result).get(validationEmailKey) shouldBe Some("pepsimac@gmail.com")
+          }
+        }
+
+        "the call doesn't return an email" should {
+
+          lazy val result = {
+            mockIndividualAuthorised()
+            mockGetCustomerInfo(user.vrn)(Right(minCustomerInfoModel))
+            testController.show(request)
+          }
+
+          "return 303" in {
+            status(result) shouldBe SEE_OTHER
+          }
+
+          "redirect to VAT Overview" in {
+            redirectLocation(result) shouldBe Some(mockConfig.vatOverviewUrl)
+          }
+        }
+      }
+
+      "the VAT subscription call is unsuccessful" should {
+
+        lazy val result = {
+          mockIndividualAuthorised()
+          mockGetCustomerInfo(user.vrn)(Left(ErrorModel(Status.INTERNAL_SERVER_ERROR, "")))
+          testController.show(request)
+        }
+
+        "return 500 (ISE)" in {
+          status(result) shouldBe INTERNAL_SERVER_ERROR
+        }
+      }
+    }
+
+    "called by an agent" should {
+
+      lazy val result = testController.show(agent)
+
+      "return 401 (Unauthorized)" in {
+        mockAgentAuthorised()
+        status(result) shouldBe UNAUTHORIZED
+      }
+    }
+
+  }
+
+  "The BouncedEmailController .submit method" when {
+
+    "called by a principal user" when {
+
+      "the user's email is in session" when {
+
+        "the form fails to bind" should {
+
+          lazy val result = testController.submit(requestWithBadFormAndEmail)
+
+          "return 400 (bad request)" in {
+            mockIndividualAuthorised()
+            status(result) shouldBe BAD_REQUEST
+          }
+        }
+
+        "the form binds successfully" when {
+
+          "the Verify Email option is bound" should {
+
+            lazy val result = {
+              mockIndividualAuthorised()
+              testController.submit(requestWithValidationEmail.withFormUrlEncodedBody("yes_no" -> "yes"))
+            }
+
+            "return 303" in {
+              status(result) shouldBe SEE_OTHER
+            }
+
+            "have the correct redirect location" in {
+              redirectLocation(result) shouldBe Some(routes.VerifyPasscodeController.emailSendVerification.url)
+            }
+
+            "add the prepop email session value" in {
+              session(result).get(prepopulationEmailKey) shouldBe Some(testEmail)
+            }
+          }
+
+          "the Add Email option is bound" should {
+
+            lazy val result = {
+              mockIndividualAuthorised()
+              testController.submit(requestWithValidationEmail.withFormUrlEncodedBody("yes_no" -> "no"))
+            }
+
+            "return 303" in {
+              status(result) shouldBe SEE_OTHER
+            }
+
+            "have the correct redirect location" in {
+              redirectLocation(result) shouldBe Some(routes.CaptureEmailController.show.url)
+            }
+
+          }
+        }
+
+      }
+
+      "the user's email is not in session" should {
+
+        lazy val result = {
+          mockIndividualAuthorised()
+          testController.submit(request.withFormUrlEncodedBody("yes_no" -> "no"))
+        }
+
+        "return ISE (500)" in {
+          status(result) shouldBe INTERNAL_SERVER_ERROR
+        }
+      }
+    }
+
+    "called by an agent" should {
+
+      lazy val result = testController.submit(agent)
+
+      "return 401 (Unauthorized)" in {
+        mockAgentAuthorised()
+        status(result) shouldBe UNAUTHORIZED
+      }
+    }
+  }
+}

--- a/test/utils/TestUtil.scala
+++ b/test/utils/TestUtil.scala
@@ -53,6 +53,9 @@ trait TestUtil extends AnyWordSpecLike with GuiceOneAppPerSuite with Materialize
   lazy val requestWithEmail: FakeRequest[AnyContentAsEmpty.type] =
     request.withSession(prepopulationEmailKey -> testEmail)
 
+  lazy val requestWithValidationEmail: FakeRequest[AnyContentAsEmpty.type] =
+    request.withSession(validationEmailKey -> testEmail)
+
   lazy val requestWithWebsite: FakeRequest[AnyContentAsEmpty.type] =
     request.withSession(validationWebsiteKey -> testWebsite, prepopulationWebsiteKey -> testWebsite)
 
@@ -105,6 +108,9 @@ trait TestUtil extends AnyWordSpecLike with GuiceOneAppPerSuite with Materialize
   lazy val requestWithPaperPref: FakeRequest[AnyContentAsEmpty.type] = request.withSession(
     currentContactPrefKey -> paper
   )
+
+  lazy val requestWithBadFormAndEmail = requestWithValidationEmail
+    .withFormUrlEncodedBody("" -> "")
 
   lazy val insolventRequest: FakeRequest[AnyContentAsEmpty.type] = request.withSession(
     insolventWithoutAccessKey -> "true"


### PR DESCRIPTION
I've plugged the YesNoForm into the action for the time being because it's most similar to the form that will eventually be used and the wiring up task should just involve a drop in replacement. Adding the view to the `Ok()` should be straightforward too.